### PR TITLE
fix: use new workflow in yaml

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,6 +1,3 @@
-workflow:
-    - publish
-
 shared:
     image: node:6
 
@@ -9,6 +6,9 @@ jobs:
         steps:
             - install: npm install
             - test: npm test
+        requires:
+            - ~pr
+            - ~commit
 
     publish:
         template: screwdriver-cd/semantic-release
@@ -17,3 +17,5 @@ jobs:
             - NPM_TOKEN
             # Pushing tags to Git
             - GH_TOKEN
+        requires:
+            - main


### PR DESCRIPTION
Fix to use the new workflow since we will deprecate the old workflow

Related: https://github.com/screwdriver-cd/screwdriver/issues/723