### PR TITLE
feat(1082):[5] Check the trigger does match the regex or not

### DIFF
--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -21,9 +21,19 @@ const getNextJobs = (workflowGraph, config) => {
     }
 
     workflowGraph.edges.forEach((edge) => {
-        const regexp = new RegExp(`^${edge.src}$`);
+        const edgeSrcBranchRegExp = new RegExp('^~commit:/(.+)/$');
+        const edgeSrcBranch = edge.src.match(edgeSrcBranchRegExp);
 
-        if (config.trigger.match(regexp)) {
+        if (edgeSrcBranch) {
+            const triggerBranchRegExp = new RegExp('^~commit:(.+)$');
+            const triggerBranch = config.trigger.match(triggerBranchRegExp);
+
+            if (triggerBranch) {
+                if (triggerBranch[1].match(edgeSrcBranch[1])) {
+                    jobs.add(edge.dest);
+                }
+            }
+        } else if (edge.src === config.trigger) {
             // Make PR jobs PR-$num:$cloneJob (not sure how to better handle multiple PR jobs)
             jobs.add(config.trigger === '~pr' ? `PR-${config.prNum}:${edge.dest}` : edge.dest);
         }

--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -21,10 +21,12 @@ const getNextJobs = (workflowGraph, config) => {
     }
 
     workflowGraph.edges.forEach((edge) => {
+        // Check if edge src is specific branch commit with regexp
         const edgeSrcBranchRegExp = new RegExp('^~commit:/(.+)/$');
         const edgeSrcBranch = edge.src.match(edgeSrcBranchRegExp);
 
         if (edgeSrcBranch) {
+            // Check if trigger is specific branch commit
             const triggerBranchRegExp = new RegExp('^~commit:(.+)$');
             const triggerBranch = config.trigger.match(triggerBranchRegExp);
 

--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -21,7 +21,9 @@ const getNextJobs = (workflowGraph, config) => {
     }
 
     workflowGraph.edges.forEach((edge) => {
-        if (edge.src === config.trigger) {
+        const regexp = new RegExp(`^${edge.src}$`);
+
+        if (config.trigger.match(regexp)) {
             // Make PR jobs PR-$num:$cloneJob (not sure how to better handle multiple PR jobs)
             jobs.add(config.trigger === '~pr' ? `PR-${config.prNum}:${edge.dest}` : edge.dest);
         }

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -46,5 +46,21 @@ describe('getNextJobs', () => {
             ['b', 'c', 'd']);
         // trigger one after job "b"
         assert.deepEqual(getNextJobs(parallelWorkflow, { trigger: 'b' }), ['e']);
+
+        const specificBranchWorkflow = {
+            edges: [
+                { src: '~commit', dest: 'a' },
+                { src: '~commit:foo', dest: 'b' },
+                { src: '~commit:dev-.*', dest: 'c' }
+            ]
+        };
+
+        // trigger own pipeline commit
+        assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~commit' }), ['a']);
+        // trigger "foo" branch commit
+        assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~commit:foo' }), ['b']);
+        // trigger "dev-bar" branch commit
+        assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~commit:dev-bar' }),
+            ['c']);
     });
 });

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -51,7 +51,8 @@ describe('getNextJobs', () => {
             edges: [
                 { src: '~commit', dest: 'a' },
                 { src: '~commit:foo', dest: 'b' },
-                { src: '~commit:dev-.*', dest: 'c' }
+                { src: '~commit:/foo-/', dest: 'c' },
+                { src: '~commit:/^bar-.*$/', dest: 'd' }
             ]
         };
 
@@ -59,8 +60,11 @@ describe('getNextJobs', () => {
         assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~commit' }), ['a']);
         // trigger "foo" branch commit
         assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~commit:foo' }), ['b']);
-        // trigger "dev-bar" branch commit
-        assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~commit:dev-bar' }),
+        // trigger "foo-bar-dev" branch commit
+        assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~commit:foo-bar-dev' }),
             ['c']);
+        // trigger "bar-foo-prod" branch commit
+        assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~commit:bar-foo-prod' }),
+            ['c', 'd']);
     });
 });


### PR DESCRIPTION
## Context
To trigger from specific branch commit, getNextJobs allow regex when check edge.src and config.trigger.

## Objective
Use edge.src as a regex and check the trigger does match the regex or not.

## References
Related to: https://github.com/screwdriver-cd/screwdriver/issues/1082