### PR TITLE
feat(1082): [13] [small] fix to enable branch specific pr trigger

### DIFF
--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -30,7 +30,9 @@ const getNextJobs = (workflowGraph, config) => {
             const triggerBranchRegExp = new RegExp('^~(pr|commit):(.+)$');
             const triggerBranch = config.trigger.match(triggerBranchRegExp);
 
+            // Check whether job types of trigger and edge src match
             if (triggerBranch && triggerBranch[1] === edgeSrcBranch[1]) {
+                // Check if trigger branch and edge src branch regex match
                 if (triggerBranch[2].match(edgeSrcBranch[2])) {
                     jobs.add(edge.dest);
                 }

--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -22,16 +22,16 @@ const getNextJobs = (workflowGraph, config) => {
 
     workflowGraph.edges.forEach((edge) => {
         // Check if edge src is specific branch commit with regexp
-        const edgeSrcBranchRegExp = new RegExp('^~commit:/(.+)/$');
+        const edgeSrcBranchRegExp = new RegExp('^~(pr|commit):/(.+)/$');
         const edgeSrcBranch = edge.src.match(edgeSrcBranchRegExp);
 
         if (edgeSrcBranch) {
             // Check if trigger is specific branch commit
-            const triggerBranchRegExp = new RegExp('^~commit:(.+)$');
+            const triggerBranchRegExp = new RegExp('^~(pr|commit):(.+)$');
             const triggerBranch = config.trigger.match(triggerBranchRegExp);
 
-            if (triggerBranch) {
-                if (triggerBranch[1].match(edgeSrcBranch[1])) {
+            if (triggerBranch && triggerBranch[1] === edgeSrcBranch[1]) {
+                if (triggerBranch[2].match(edgeSrcBranch[2])) {
                     jobs.add(edge.dest);
                 }
             }

--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -21,12 +21,12 @@ const getNextJobs = (workflowGraph, config) => {
     }
 
     workflowGraph.edges.forEach((edge) => {
-        // Check if edge src is specific branch commit with regexp
+        // Check if edge src is specific branch commit or pr with regexp
         const edgeSrcBranchRegExp = new RegExp('^~(pr|commit):/(.+)/$');
         const edgeSrcBranch = edge.src.match(edgeSrcBranchRegExp);
 
         if (edgeSrcBranch) {
-            // Check if trigger is specific branch commit
+            // Check if trigger is specific branch commit or pr
             const triggerBranchRegExp = new RegExp('^~(pr|commit):(.+)$');
             const triggerBranch = config.trigger.match(triggerBranchRegExp);
 

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -52,7 +52,10 @@ describe('getNextJobs', () => {
                 { src: '~commit', dest: 'a' },
                 { src: '~commit:foo', dest: 'b' },
                 { src: '~commit:/foo-/', dest: 'c' },
-                { src: '~commit:/^bar-.*$/', dest: 'd' }
+                { src: '~commit:/^bar-.*$/', dest: 'd' },
+                { src: '~pr:foo', dest: 'e' },
+                { src: '~pr:/foo-/', dest: 'f' },
+                { src: '~pr:/^bar-.*$/', dest: 'g' }
             ]
         };
 
@@ -66,5 +69,14 @@ describe('getNextJobs', () => {
         // trigger "bar-foo-prod" branch commit
         assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~commit:bar-foo-prod' }),
             ['c', 'd']);
+        // trigger by a pull request on "foo" branch
+        assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~pr:foo', prNum: '123' }),
+            ['e']);
+        // trigger by a pull request on "foo-bar-dev" branch
+        assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~pr:foo-bar-dev',
+            prNum: '123' }), ['f']);
+        // trigger by a pull request on "bar-foo-prod" branch
+        assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~pr:bar-foo-prod',
+            prNum: '123' }), ['f', 'g']);
     });
 });


### PR DESCRIPTION
## Context
The branch specific trigger for `~pr` is not implemented yet.

## Objective
* Fix trigger checking logic for branch  specific `~pr` jobs

## References
* [workflow design](https://github.com/screwdriver-cd/screwdriver/blob/master/design/workflow.md#branch-filtering-scm-branch-specific-jobs)
* issue https://github.com/screwdriver-cd/screwdriver/issues/1082