### PR TITLE
[3] feat(1010): enable to use prChain on getNextJobs()

### DIFF
--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -7,6 +7,7 @@
  * @param  {Object}    config
  * @param  {String}    config.trigger      The triggering event (~pr, ~commit, jobName)
  * @param  {String}    [config.prNum]      The PR number (required when ~pr trigger)
+ * @param  {Boolean}   [config.prChain]    The flag for PR jobs will trigger subsequent jobs
  * @return {Array}                      List of job names
  */
 const getNextJobs = (workflowGraph, config) => {
@@ -39,7 +40,11 @@ const getNextJobs = (workflowGraph, config) => {
             }
         } else if (edge.src === config.trigger) {
             // Make PR jobs PR-$num:$cloneJob (not sure how to better handle multiple PR jobs)
-            jobs.add(config.trigger === '~pr' ? `PR-${config.prNum}:${edge.dest}` : edge.dest);
+            if (config.trigger === '~pr' && !config.prChain) {
+                jobs.add(`PR-${config.prNum}:${edge.dest}`);
+            } else {
+                jobs.add(edge.dest);
+            }
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   ],
   "devDependencies": {
     "chai": "^4.1.2",
-    "eslint": "^4.8.0",
+    "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^5.0.0"
+    "jenkins-mocha": "^6.0.0"
   },
   "dependencies": {},
   "release": {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -31,6 +31,12 @@ describe('getNextJobs', () => {
         assert.deepEqual(getNextJobs(WORKFLOW, { trigger: 'bar' }), []);
         // trigger after non-existing job "main"
         assert.deepEqual(getNextJobs(WORKFLOW, { trigger: 'banana' }), []);
+        // trigger for a pr event with prChain
+        assert.deepEqual(getNextJobs(WORKFLOW, {
+            trigger: '~pr',
+            prNum: '123',
+            prChain: true
+        }), ['main']);
 
         const parallelWorkflow = {
             edges: [


### PR DESCRIPTION
## Context
We want to implement `prChain` feature. If `prChain` is true, a job name does not have `PR-` prefix. 

## Objective
This PR enables to use `prChain` in `getNextJobs()`.
This PR also update node version to 8 from 6.
This change may have backward compatibility.

## Misc.
Related Issue: https://github.com/screwdriver-cd/screwdriver/issues/1010
Related PRs:
- https://github.com/screwdriver-cd/data-schema/pull/296
- https://github.com/screwdriver-cd/config-parser/pull/81