### PR TITLE
feat(1010): [1] enabling prChain 2nd step

### DIFF
--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -48,12 +48,8 @@ const getNextJobs = (workflowGraph, config) => {
             } else {
                 jobs.add(edge.dest);
             }
-        } else if (config.prChain) {
-            if (config.trigger === '~pr') {
-                jobs.add(`PR-${config.prNum}:${edge.dest}`);
-            } else if (prChainTrigger && config.trigger === `${prChainTrigger[1]}${edge.src}`) {
-                jobs.add(`${prChainTrigger[1]}${edge.dest}`);
-            }
+        } else if (prChainTrigger && config.trigger === `${prChainTrigger[1]}${edge.src}`) {
+            jobs.add(`${prChainTrigger[1]}${edge.dest}`);
         }
     });
 

--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -50,6 +50,7 @@ const getNextJobs = (workflowGraph, config) => {
             } else {
                 jobs.add(edge.dest);
             }
+        // prChainTrigger[1] must be 'PR-$num' if matches regexp
         } else if (prChainTrigger && config.trigger === `${prChainTrigger[1]}:${edge.src}`) {
             jobs.add(`${prChainTrigger[1]}:${edge.dest}`);
         }

--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -21,6 +21,9 @@ const getNextJobs = (workflowGraph, config) => {
         throw new Error('Must provide a PR number with "~pr" trigger');
     }
 
+    // Check if the job is triggerd by prChain with regexp
+    const prChainTrigger = config.trigger.match(/^(PR-[0-9]+:)?[\w-]+$/u);
+
     workflowGraph.edges.forEach((edge) => {
         // Check if edge src is specific branch commit or pr with regexp
         const edgeSrcBranchRegExp = new RegExp('^~(pr|commit):/(.+)/$');
@@ -40,10 +43,16 @@ const getNextJobs = (workflowGraph, config) => {
             }
         } else if (edge.src === config.trigger) {
             // Make PR jobs PR-$num:$cloneJob (not sure how to better handle multiple PR jobs)
-            if (config.trigger === '~pr' && !config.prChain) {
+            if (config.trigger === '~pr') {
                 jobs.add(`PR-${config.prNum}:${edge.dest}`);
             } else {
                 jobs.add(edge.dest);
+            }
+        } else if (config.prChain) {
+            if (config.trigger === '~pr') {
+                jobs.add(`PR-${config.prNum}:${edge.dest}`);
+            } else if (prChainTrigger && config.trigger === `${prChainTrigger[1]}${edge.src}`) {
+                jobs.add(`${prChainTrigger[1]}${edge.dest}`);
             }
         }
     });

--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { PR_JOB_NAME } = require('screwdriver-data-schema').config.regex;
+
 /**
  * Calculate the next jobs to execute, given a workflow and a trigger job
  * @method getNextJobs
@@ -22,7 +24,7 @@ const getNextJobs = (workflowGraph, config) => {
     }
 
     // Check if the job is triggerd by prChain with regexp
-    const prChainTrigger = config.trigger.match(/^(PR-[0-9]+:)?[\w-]+$/u);
+    const prChainTrigger = config.trigger.match(PR_JOB_NAME);
 
     workflowGraph.edges.forEach((edge) => {
         // Check if edge src is specific branch commit or pr with regexp
@@ -48,8 +50,8 @@ const getNextJobs = (workflowGraph, config) => {
             } else {
                 jobs.add(edge.dest);
             }
-        } else if (prChainTrigger && config.trigger === `${prChainTrigger[1]}${edge.src}`) {
-            jobs.add(`${prChainTrigger[1]}${edge.dest}`);
+        } else if (prChainTrigger && config.trigger === `${prChainTrigger[1]}:${edge.src}`) {
+            jobs.add(`${prChainTrigger[1]}:${edge.dest}`);
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^6.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "screwdriver-data-schema": "^18.39.2"
+  },
   "release": {
     "debug": false,
     "verifyConditions": {

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -36,7 +36,27 @@ describe('getNextJobs', () => {
             trigger: '~pr',
             prNum: '123',
             prChain: true
-        }), ['main']);
+        }),
+        [
+            'PR-123:main',
+            'PR-123:foo',
+            'PR-123:bar'
+        ]);
+        // trigger after job "PR-123:main" with prChain
+        assert.deepEqual(getNextJobs(WORKFLOW, {
+            trigger: 'PR-123:main',
+            prChain: true
+        }), ['PR-123:foo']);
+        // trigger after job "PR-123:foo" with prChain
+        assert.deepEqual(getNextJobs(WORKFLOW, {
+            trigger: 'PR-123:foo',
+            prChain: true
+        }), ['PR-123:bar']);
+        // trigger after job "PR-123:var" with prChain
+        assert.deepEqual(getNextJobs(WORKFLOW, {
+            trigger: 'PR-123:bar',
+            prChain: true
+        }), []);
 
         const parallelWorkflow = {
             edges: [

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -37,11 +37,7 @@ describe('getNextJobs', () => {
             prNum: '123',
             prChain: true
         }),
-        [
-            'PR-123:main',
-            'PR-123:foo',
-            'PR-123:bar'
-        ]);
+        ['PR-123:main']);
         // trigger after job "PR-123:main" with prChain
         assert.deepEqual(getNextJobs(WORKFLOW, {
             trigger: 'PR-123:main',


### PR DESCRIPTION
## Context
This PR is the second step of enabling prChain feature.
This time we fixed only a backend（api, models, workflow-graph）. UI will be fixed next time.

## Objective
- If `prChain` flag is true in screwdriver.yaml, run subsequent jobs following workflow graph.
- Create all jobs with `PR-${prNum}:` prefix.

## Other PRs
https://github.com/screwdriver-cd/screwdriver/pull/1444
https://github.com/screwdriver-cd/models/pull/315

## References
- New design of prChain feature
https://github.com/screwdriver-cd/screwdriver/issues/1010#issuecomment-448142968
