### PR TITLE
feat(823): [2] add ~release and ~tag as special trigger

### DIFF
--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -28,12 +28,12 @@ const getNextJobs = (workflowGraph, config) => {
 
     workflowGraph.edges.forEach((edge) => {
         // Check if edge src is specific branch commit or pr with regexp
-        const edgeSrcBranchRegExp = new RegExp('^~(pr|commit):/(.+)/$');
+        const edgeSrcBranchRegExp = new RegExp('^~(pr|commit|release|tag):/(.+)/$');
         const edgeSrcBranch = edge.src.match(edgeSrcBranchRegExp);
 
         if (edgeSrcBranch) {
             // Check if trigger is specific branch commit or pr
-            const triggerBranchRegExp = new RegExp('^~(pr|commit):(.+)$');
+            const triggerBranchRegExp = new RegExp('^~(pr|commit|release|tag):(.+)$');
             const triggerBranch = config.trigger.match(triggerBranchRegExp);
 
             // Check whether job types of trigger and edge src match

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -6,7 +6,8 @@
  * @param  {String}       name A Node Name, e.g. foo, ~foo, ~pr, ~commit, ~sd@1234:foo
  * @return {String}            A filtered node name, e.g. foo, foo, ~pr, ~commit, ~sd@1234:foo
  */
-const filterNodeName = name => (/^~(pr|commit|sd@)/.test(name) ? name : name.replace('~', ''));
+const filterNodeName = name =>
+    (/^~(pr|commit|release|tag|sd@)/.test(name) ? name : name.replace('~', ''));
 
 /**
  * Get the list of nodes for the graph
@@ -15,7 +16,7 @@ const filterNodeName = name => (/^~(pr|commit|sd@)/.test(name) ? name : name.rep
  * @return {Array}             List of nodes (jobs)
  */
 const calculateNodes = (jobs) => {
-    const nodes = new Set(['~pr', '~commit']);
+    const nodes = new Set(['~pr', '~commit', '~release', '~tag']);
 
     Object.keys(jobs).forEach((name) => {
         nodes.add(name);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chai": "^4.1.2",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^6.0.0"
+    "jenkins-mocha": "^7.0.0"
   },
   "dependencies": {
     "screwdriver-data-schema": "^18.39.2"

--- a/test/data/expected-external.json
+++ b/test/data/expected-external.json
@@ -2,16 +2,21 @@
     "nodes": [
         { "name": "~pr" },
         { "name": "~commit" },
+        { "name": "~release" },
+        { "name": "~tag" },
         { "name": "main" },
         { "name": "foo" },
         { "name": "bar" },
-        { "name": "~sd@1234:foo" }
+        { "name": "~sd@1234:foo" },
+        { "name": "baz" }
     ],
     "edges": [
         { "src": "~pr", "dest": "main" },
         { "src": "~commit", "dest": "main" },
         { "src": "main", "dest": "foo" },
         { "src": "~sd@1234:foo", "dest": "bar" },
-        { "src": "foo", "dest": "bar" }
+        { "src": "foo", "dest": "bar" },
+        { "src": "~release", "dest": "baz" },
+        { "src": "~tag", "dest": "baz" }
     ]
 }

--- a/test/data/expected-output.json
+++ b/test/data/expected-output.json
@@ -2,14 +2,19 @@
     "nodes": [
         { "name": "~pr" },
         { "name": "~commit" },
+        { "name": "~release" },
+        { "name": "~tag" },
         { "name": "main" },
         { "name": "foo" },
-        { "name": "bar" }
+        { "name": "bar" },
+        { "name": "baz" }
     ],
     "edges": [
         { "src": "~pr", "dest": "main" },
         { "src": "~commit", "dest": "main" },
         { "src": "main", "dest": "foo" },
-        { "src": "foo", "dest": "bar" }
+        { "src": "foo", "dest": "bar" },
+        { "src": "~release", "dest": "baz" },
+        { "src": "~tag", "dest": "baz" }
     ]
 }

--- a/test/data/requires-workflow-exttrigger.json
+++ b/test/data/requires-workflow-exttrigger.json
@@ -2,6 +2,7 @@
     "jobs": {
         "main": { "requires": ["~pr", "~commit"] },
         "foo": { "requires": ["main"] },
-        "bar": { "requires": ["foo", "~sd@1234:foo"] }
+        "bar": { "requires": ["foo", "~sd@1234:foo"] },
+        "baz": { "requires": ["~release", "~tag"] }
     }
 }

--- a/test/data/requires-workflow.json
+++ b/test/data/requires-workflow.json
@@ -2,6 +2,7 @@
     "jobs": {
         "main": { "requires": ["~pr", "~commit"] },
         "foo": { "requires": ["main"] },
-        "bar": { "requires": ["foo"] }
+        "bar": { "requires": ["foo"] },
+        "baz": { "requires": ["~release", "~tag"] }
     }
 }

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -23,6 +23,10 @@ describe('getNextJobs', () => {
         }), ['PR-123:main']);
         // trigger for commit event
         assert.deepEqual(getNextJobs(WORKFLOW, { trigger: '~commit' }), ['main']);
+        // trigger for release event
+        assert.deepEqual(getNextJobs(WORKFLOW, { trigger: '~release' }), ['baz']);
+        // trigger for tag event
+        assert.deepEqual(getNextJobs(WORKFLOW, { trigger: '~tag' }), ['baz']);
         // trigger after job "main"
         assert.deepEqual(getNextJobs(WORKFLOW, { trigger: 'main' }), ['foo']);
         // trigger after job "foo"
@@ -53,7 +57,9 @@ describe('getNextJobs', () => {
             trigger: 'PR-123:bar',
             prChain: true
         }), []);
+    });
 
+    it('should figure out what jobs start next with parallel workflow', () => {
         const parallelWorkflow = {
             edges: [
                 { src: 'a', dest: 'b' },
@@ -68,7 +74,9 @@ describe('getNextJobs', () => {
             ['b', 'c', 'd']);
         // trigger one after job "b"
         assert.deepEqual(getNextJobs(parallelWorkflow, { trigger: 'b' }), ['e']);
+    });
 
+    it('should figure out what jobs start next with specific branch workflow', () => {
         const specificBranchWorkflow = {
             edges: [
                 { src: '~commit', dest: 'a' },

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -38,7 +38,14 @@ describe('getWorkflow', () => {
         });
 
         assert.deepEqual(result, {
-            nodes: [{ name: '~pr' }, { name: '~commit' }, { name: 'foo' }, { name: 'bar' }],
+            nodes: [
+                { name: '~pr' },
+                { name: '~commit' },
+                { name: '~release' },
+                { name: '~tag' },
+                { name: 'foo' },
+                { name: 'bar' }
+            ],
             edges: [{ src: 'foo', dest: 'bar' }]
         });
     });
@@ -57,6 +64,8 @@ describe('getWorkflow', () => {
             nodes: [
                 { name: '~pr' },
                 { name: '~commit' },
+                { name: '~release' },
+                { name: '~tag' },
                 { name: 'foo' },
                 { name: 'A' },
                 { name: 'B' },
@@ -90,6 +99,8 @@ describe('getWorkflow', () => {
             nodes: [
                 { name: '~pr' },
                 { name: '~commit' },
+                { name: '~release' },
+                { name: '~tag' },
                 { name: 'foo' },
                 { name: 'A' },
                 { name: 'B' },
@@ -121,6 +132,8 @@ describe('getWorkflow', () => {
             nodes: [
                 { name: '~pr' },
                 { name: '~commit' },
+                { name: '~release' },
+                { name: '~tag' },
                 { name: 'foo' },
                 { name: 'A' }
             ],
@@ -144,6 +157,8 @@ describe('getWorkflow', () => {
             nodes: [
                 { name: '~pr' },
                 { name: '~commit' },
+                { name: '~release' },
+                { name: '~tag' },
                 { name: 'foo' },
                 { name: 'bar' },
                 { name: 'baz' },


### PR DESCRIPTION
To implement `~release` and `~tag` trigger, this PR adds these trigger as a special trigger and a node.

#### Related
- Issue: https://github.com/screwdriver-cd/screwdriver/issues/823
- data-schema: https://github.com/screwdriver-cd/data-schema/pull/320