### PR TITLE
feat(823): not to add ~release and ~tag node as a default node

### DIFF
--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -3,8 +3,8 @@
 /**
  * Remove the ~ prefix for logical OR on select node names.
  * @method filterNodeName
- * @param  {String}       name A Node Name, e.g. foo, ~foo, ~pr, ~commit, ~sd@1234:foo
- * @return {String}            A filtered node name, e.g. foo, foo, ~pr, ~commit, ~sd@1234:foo
+ * @param  {String}       name A Node Name, e.g. foo, ~foo, ~pr, ~commit, ~release, ~tag, ~sd@1234:foo
+ * @return {String}            A filtered node name, e.g. foo, foo, ~pr, ~commit, ~release, ~tag, ~sd@1234:foo
  */
 const filterNodeName = name =>
     (/^~(pr|commit|release|tag|sd@)/.test(name) ? name : name.replace('~', ''));
@@ -16,7 +16,7 @@ const filterNodeName = name =>
  * @return {Array}             List of nodes (jobs)
  */
 const calculateNodes = (jobs) => {
-    const nodes = new Set(['~pr', '~commit', '~release', '~tag']);
+    const nodes = new Set(['~pr', '~commit']);
 
     Object.keys(jobs).forEach((name) => {
         nodes.add(name);

--- a/test/data/expected-external.json
+++ b/test/data/expected-external.json
@@ -2,21 +2,16 @@
     "nodes": [
         { "name": "~pr" },
         { "name": "~commit" },
-        { "name": "~release" },
-        { "name": "~tag" },
         { "name": "main" },
         { "name": "foo" },
         { "name": "bar" },
-        { "name": "~sd@1234:foo" },
-        { "name": "baz" }
+        { "name": "~sd@1234:foo" }
     ],
     "edges": [
         { "src": "~pr", "dest": "main" },
         { "src": "~commit", "dest": "main" },
         { "src": "main", "dest": "foo" },
         { "src": "~sd@1234:foo", "dest": "bar" },
-        { "src": "foo", "dest": "bar" },
-        { "src": "~release", "dest": "baz" },
-        { "src": "~tag", "dest": "baz" }
+        { "src": "foo", "dest": "bar" }
     ]
 }

--- a/test/data/expected-output.json
+++ b/test/data/expected-output.json
@@ -2,12 +2,12 @@
     "nodes": [
         { "name": "~pr" },
         { "name": "~commit" },
-        { "name": "~release" },
-        { "name": "~tag" },
         { "name": "main" },
         { "name": "foo" },
         { "name": "bar" },
-        { "name": "baz" }
+        { "name": "baz" },
+        { "name": "~release" },
+        { "name": "~tag" }
     ],
     "edges": [
         { "src": "~pr", "dest": "main" },

--- a/test/data/requires-workflow-exttrigger.json
+++ b/test/data/requires-workflow-exttrigger.json
@@ -2,7 +2,6 @@
     "jobs": {
         "main": { "requires": ["~pr", "~commit"] },
         "foo": { "requires": ["main"] },
-        "bar": { "requires": ["foo", "~sd@1234:foo"] },
-        "baz": { "requires": ["~release", "~tag"] }
+        "bar": { "requires": ["foo", "~sd@1234:foo"] }
     }
 }

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -41,8 +41,6 @@ describe('getWorkflow', () => {
             nodes: [
                 { name: '~pr' },
                 { name: '~commit' },
-                { name: '~release' },
-                { name: '~tag' },
                 { name: 'foo' },
                 { name: 'bar' }
             ],
@@ -64,8 +62,6 @@ describe('getWorkflow', () => {
             nodes: [
                 { name: '~pr' },
                 { name: '~commit' },
-                { name: '~release' },
-                { name: '~tag' },
                 { name: 'foo' },
                 { name: 'A' },
                 { name: 'B' },
@@ -99,8 +95,6 @@ describe('getWorkflow', () => {
             nodes: [
                 { name: '~pr' },
                 { name: '~commit' },
-                { name: '~release' },
-                { name: '~tag' },
                 { name: 'foo' },
                 { name: 'A' },
                 { name: 'B' },
@@ -132,8 +126,6 @@ describe('getWorkflow', () => {
             nodes: [
                 { name: '~pr' },
                 { name: '~commit' },
-                { name: '~release' },
-                { name: '~tag' },
                 { name: 'foo' },
                 { name: 'A' }
             ],
@@ -157,8 +149,6 @@ describe('getWorkflow', () => {
             nodes: [
                 { name: '~pr' },
                 { name: '~commit' },
-                { name: '~release' },
-                { name: '~tag' },
                 { name: 'foo' },
                 { name: 'bar' },
                 { name: 'baz' },


### PR DESCRIPTION
This PR fixes https://github.com/screwdriver-cd/workflow-parser/pull/18#issuecomment-470328721 
> we shouldn't add ~tag and ~release to the default nodes. We should only add those if user configure it in the requires. Otherwise those will always show up in the UI.

Related: https://github.com/screwdriver-cd/screwdriver/issues/823