### PR TITLE
fix: [2] convert prChain to chainPR

### DIFF
--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -9,7 +9,7 @@ const { PR_JOB_NAME } = require('screwdriver-data-schema').config.regex;
  * @param  {Object}    config
  * @param  {String}    config.trigger      The triggering event (~pr, ~commit, jobName)
  * @param  {String}    [config.prNum]      The PR number (required when ~pr trigger)
- * @param  {Boolean}   [config.prChain]    The flag for PR jobs will trigger subsequent jobs
+ * @param  {Boolean}   [config.chainPR]    The flag for PR jobs will trigger subsequent jobs
  * @return {Array}                      List of job names
  */
 const getNextJobs = (workflowGraph, config) => {
@@ -23,8 +23,8 @@ const getNextJobs = (workflowGraph, config) => {
         throw new Error('Must provide a PR number with "~pr" trigger');
     }
 
-    // Check if the job is triggerd by prChain with regexp
-    const prChainTrigger = config.trigger.match(PR_JOB_NAME);
+    // Check if the job is triggerd by chainPR with regexp
+    const chainPRTrigger = config.trigger.match(PR_JOB_NAME);
 
     workflowGraph.edges.forEach((edge) => {
         // Check if edge src is specific branch commit or pr with regexp
@@ -50,10 +50,10 @@ const getNextJobs = (workflowGraph, config) => {
             } else {
                 jobs.add(edge.dest);
             }
-        // prChainTrigger[1] must be 'PR-$num' if matches regexp
-        } else if (config.prChain
-                && prChainTrigger && config.trigger === `${prChainTrigger[1]}:${edge.src}`) {
-            jobs.add(`${prChainTrigger[1]}:${edge.dest}`);
+        // chainPRTrigger[1] must be 'PR-$num' if matches regexp
+        } else if (config.chainPR
+                && chainPRTrigger && config.trigger === `${chainPRTrigger[1]}:${edge.src}`) {
+            jobs.add(`${chainPRTrigger[1]}:${edge.dest}`);
         }
     });
 

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -35,27 +35,27 @@ describe('getNextJobs', () => {
         assert.deepEqual(getNextJobs(WORKFLOW, { trigger: 'bar' }), []);
         // trigger after non-existing job "main"
         assert.deepEqual(getNextJobs(WORKFLOW, { trigger: 'banana' }), []);
-        // trigger for a pr event with prChain
+        // trigger for a pr event with chainPR
         assert.deepEqual(getNextJobs(WORKFLOW, {
             trigger: '~pr',
             prNum: '123',
-            prChain: true
+            chainPR: true
         }),
         ['PR-123:main']);
-        // trigger after job "PR-123:main" with prChain
+        // trigger after job "PR-123:main" with chainPR
         assert.deepEqual(getNextJobs(WORKFLOW, {
             trigger: 'PR-123:main',
-            prChain: true
+            chainPR: true
         }), ['PR-123:foo']);
-        // trigger after job "PR-123:foo" with prChain
+        // trigger after job "PR-123:foo" with chainPR
         assert.deepEqual(getNextJobs(WORKFLOW, {
             trigger: 'PR-123:foo',
-            prChain: true
+            chainPR: true
         }), ['PR-123:bar']);
-        // trigger after job "PR-123:var" with prChain
+        // trigger after job "PR-123:var" with chainPR
         assert.deepEqual(getNextJobs(WORKFLOW, {
             trigger: 'PR-123:bar',
-            prChain: true
+            chainPR: true
         }), []);
     });
 


### PR DESCRIPTION
## Context
Now there are orthographical variants like 'prChain' and 'chainPR' .
We want to unify these to `chainPR`.

## Objective
Add `chainPR` setter/getter method to pipeline model in order to convert the `prChain` to `chainPR`.
We don't change `prChain` property itself because it is already used in data-schema and it takes too much cost to change this.

## References
https://github.com/screwdriver-cd/data-schema/pull/330
https://github.com/screwdriver-cd/models/pull/371
https://github.com/screwdriver-cd/screwdriver/pull/1593
