### PR TITLE
fix(1537): [1] Fix ~pr trigger and ~pr:branch trigger have the same behavior

### DIFF
--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -40,12 +40,16 @@ const getNextJobs = (workflowGraph, config) => {
             if (triggerBranch && triggerBranch[1] === edgeSrcBranch[1]) {
                 // Check if trigger branch and edge src branch regex match
                 if (triggerBranch[2].match(edgeSrcBranch[2])) {
-                    jobs.add(edge.dest);
+                    if (config.trigger.startsWith('~pr')) {
+                        jobs.add(`PR-${config.prNum}:${edge.dest}`);
+                    } else {
+                        jobs.add(edge.dest);
+                    }
                 }
             }
         } else if (edge.src === config.trigger) {
             // Make PR jobs PR-$num:$cloneJob (not sure how to better handle multiple PR jobs)
-            if (config.trigger === '~pr') {
+            if (config.trigger === '~pr' || config.trigger.startsWith('~pr:')) {
                 jobs.add(`PR-${config.prNum}:${edge.dest}`);
             } else {
                 jobs.add(edge.dest);

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -101,12 +101,12 @@ describe('getNextJobs', () => {
             ['c', 'd']);
         // trigger by a pull request on "foo" branch
         assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~pr:foo', prNum: '123' }),
-            ['e']);
+            ['PR-123:e']);
         // trigger by a pull request on "foo-bar-dev" branch
         assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~pr:foo-bar-dev',
-            prNum: '123' }), ['f']);
+            prNum: '123' }), ['PR-123:f']);
         // trigger by a pull request on "bar-foo-prod" branch
         assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~pr:bar-foo-prod',
-            prNum: '123' }), ['f', 'g']);
+            prNum: '123' }), ['PR-123:f', 'PR-123:g']);
     });
 });


### PR DESCRIPTION
## Context
We want to use PR environment variables  in a build which is triggered by branch specific pr trigger.
https://github.com/screwdriver-cd/screwdriver/issues/1537
To fix this problem, we should treat pr trigger event and branch specific pr trigger event the same.

## Objective
Add `PR-$num:` to job name when trigger is branch specific pr.

## References
https://github.com/screwdriver-cd/screwdriver/issues/1537
https://github.com/screwdriver-cd/screwdriver/pull/1594