### PR TITLE
fix: Revert "fix(1537): [1] Fix ~pr trigger and ~pr:branch trigger have the same behavior"

### DIFF
--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -40,16 +40,12 @@ const getNextJobs = (workflowGraph, config) => {
             if (triggerBranch && triggerBranch[1] === edgeSrcBranch[1]) {
                 // Check if trigger branch and edge src branch regex match
                 if (triggerBranch[2].match(edgeSrcBranch[2])) {
-                    if (config.trigger.startsWith('~pr')) {
-                        jobs.add(`PR-${config.prNum}:${edge.dest}`);
-                    } else {
-                        jobs.add(edge.dest);
-                    }
+                    jobs.add(edge.dest);
                 }
             }
         } else if (edge.src === config.trigger) {
             // Make PR jobs PR-$num:$cloneJob (not sure how to better handle multiple PR jobs)
-            if (config.trigger === '~pr' || config.trigger.startsWith('~pr:')) {
+            if (config.trigger === '~pr') {
                 jobs.add(`PR-${config.prNum}:${edge.dest}`);
             } else {
                 jobs.add(edge.dest);

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -101,12 +101,12 @@ describe('getNextJobs', () => {
             ['c', 'd']);
         // trigger by a pull request on "foo" branch
         assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~pr:foo', prNum: '123' }),
-            ['PR-123:e']);
+            ['e']);
         // trigger by a pull request on "foo-bar-dev" branch
         assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~pr:foo-bar-dev',
-            prNum: '123' }), ['PR-123:f']);
+            prNum: '123' }), ['f']);
         // trigger by a pull request on "bar-foo-prod" branch
         assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~pr:bar-foo-prod',
-            prNum: '123' }), ['PR-123:f', 'PR-123:g']);
+            prNum: '123' }), ['f', 'g']);
     });
 });


### PR DESCRIPTION
Reverts screwdriver-cd/workflow-parser#22

This is breaking a test in model: https://cd.screwdriver.cd/pipelines/9/builds/113610/steps/test
Need to push out a change in the model, so need to revert this change.

Please feel free to reopen/remerge once figure out the issue.