### PR TITLE
fix: [1]Join job does not work when chainPR workflow

### DIFF
--- a/lib/getSrcForJoin.js
+++ b/lib/getSrcForJoin.js
@@ -1,6 +1,76 @@
 'use strict';
 
 /**
+ * Find the non PR job from given workflowGragh and dest job
+ * @method findJob
+ * @param  {Object} workflowGraph       Directed graph representation of workflow
+ * @param  {String} destJobName         The dest job name to be triggered after a join
+ * @return {Array}                      List of node object consists of job name and id
+ */
+function findJobs(workflowGraph, destJobName) {
+    const jobs = new Set();
+
+    workflowGraph.edges.forEach((edge) => {
+        if (edge.dest === destJobName && edge.join) {
+            jobs.add(workflowGraph.nodes.find(node => node.name === edge.src));
+        }
+    });
+
+    return jobs;
+}
+
+/**
+ * Find the PR job from given workflowGragh and dest job
+ * Given dest job includes `PR-{PR number}:` prefix, so it need to remove prefix to first
+ * @method findJobs
+ * @param  {Object} workflowGraph       Directed graph representation of workflow
+ * @param  {String} destJobName         The dest job name to be triggered after a join
+ * @return {Array}                      List of node object consists of job name and id
+ */
+function findPRJobs(workflowGraph, destJobName) {
+    const jobs = new Set();
+    const [prPrefix, prJobName] = destJobName.split(':');
+
+    workflowGraph.edges.forEach((edge) => {
+        if (edge.dest === prJobName && edge.join) {
+            const findJob = Object.assign({},
+                workflowGraph.nodes.find(node => node.name === edge.src));
+
+            findJob.name = `${prPrefix}:${findJob.name}`;
+            jobs.add(findJob);
+        }
+    });
+
+    return jobs;
+}
+
+/**
+ * Return PR job or not
+ * PR job name certainly has ":". e.g. "PR-1:jobName"
+ * @method isPR
+ * @param  {String}  destJobName
+ * @return {Boolean}
+ */
+function isPR(destJobName) {
+    return destJobName.includes(':');
+}
+
+/**
+ * Return the join src jobs
+ * @method getJoinJobs
+ * @param  {Object} workflowGraph       Directed graph representation of workflow
+ * @param  {String} destJobName         The dest job name to be triggered after a join
+ * @return {Array}                      List of node object consists of job name and id
+ */
+function getJoinJobs(workflowGraph, destJobName) {
+    if (isPR(destJobName)) {
+        return findPRJobs(workflowGraph, destJobName);
+    }
+
+    return findJobs(workflowGraph, destJobName);
+}
+
+/**
  * Return the join src jobs given a workflowGraph and dest job
  * @method getSrcForJoin
  * @param  {Object}    workflowGraph    Directed graph representation of workflow
@@ -9,17 +79,13 @@
  * @return {Array}                      List of node object consists of job name and id
  */
 const getSrcForJoin = (workflowGraph, config) => {
-    const jobs = new Set();
+    let jobs = new Set();
 
     if (!config || !config.jobName) {
         throw new Error('Must provide a job name');
     }
 
-    workflowGraph.edges.forEach((edge) => {
-        if (edge.dest === config.jobName && edge.join) {
-            jobs.add(workflowGraph.nodes.find(node => node.name === edge.src));
-        }
-    });
+    jobs = getJoinJobs(workflowGraph, config.jobName);
 
     return Array.from(jobs);
 };

--- a/lib/getSrcForJoin.js
+++ b/lib/getSrcForJoin.js
@@ -21,8 +21,8 @@ function findJobs(workflowGraph, destJobName) {
 
 /**
  * Find the PR job from given workflowGragh and dest job
- * Given dest job includes `PR-{PR number}:` prefix, so it need to remove prefix to first
- * @method findJobs
+ * Given dest job includes `PR-{PR number}:` prefix, so it need to remove prefix at first
+ * @method findPRJobs
  * @param  {Object} workflowGraph       Directed graph representation of workflow
  * @param  {String} destJobName         The dest job name to be triggered after a join
  * @return {Array}                      List of node object consists of job name and id
@@ -36,6 +36,7 @@ function findPRJobs(workflowGraph, destJobName) {
             const findJob = Object.assign({},
                 workflowGraph.nodes.find(node => node.name === edge.src));
 
+            // need to add `PR-{PR number}:` prefix when returning
             findJob.name = `${prPrefix}:${findJob.name}`;
             jobs.add(findJob);
         }
@@ -48,7 +49,7 @@ function findPRJobs(workflowGraph, destJobName) {
  * Return PR job or not
  * PR job name certainly has ":". e.g. "PR-1:jobName"
  * @method isPR
- * @param  {String}  destJobName
+ * @param  {String}  destJobName       The dest job name which has 'PR-{num}:' prefix
  * @return {Boolean}
  */
 function isPR(destJobName) {
@@ -79,13 +80,11 @@ function getJoinJobs(workflowGraph, destJobName) {
  * @return {Array}                      List of node object consists of job name and id
  */
 const getSrcForJoin = (workflowGraph, config) => {
-    let jobs = new Set();
-
     if (!config || !config.jobName) {
         throw new Error('Must provide a job name');
     }
 
-    jobs = getJoinJobs(workflowGraph, config.jobName);
+    const jobs = getJoinJobs(workflowGraph, config.jobName);
 
     return Array.from(jobs);
 };

--- a/lib/getSrcForJoin.js
+++ b/lib/getSrcForJoin.js
@@ -5,7 +5,7 @@
  * @method findJob
  * @param  {Object} workflowGraph       Directed graph representation of workflow
  * @param  {String} destJobName         The dest job name to be triggered after a join
- * @return {Array}                      List of node object consists of job name and id
+ * @return {Set}                        List of node object consists of job name and id
  */
 function findJobs(workflowGraph, destJobName) {
     const jobs = new Set();
@@ -25,7 +25,7 @@ function findJobs(workflowGraph, destJobName) {
  * @method findPRJobs
  * @param  {Object} workflowGraph       Directed graph representation of workflow
  * @param  {String} destJobName         The dest job name to be triggered after a join
- * @return {Array}                      List of node object consists of job name and id
+ * @return {Set}                        List of node object consists of job name and id
  */
 function findPRJobs(workflowGraph, destJobName) {
     const jobs = new Set();
@@ -61,7 +61,7 @@ function isPR(destJobName) {
  * @method getJoinJobs
  * @param  {Object} workflowGraph       Directed graph representation of workflow
  * @param  {String} destJobName         The dest job name to be triggered after a join
- * @return {Array}                      List of node object consists of job name and id
+ * @return {Set}                        List of node object consists of job name and id
  */
 function getJoinJobs(workflowGraph, destJobName) {
     if (isPR(destJobName)) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "chai": "^4.1.2",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^7.0.0"
+    "jenkins-mocha": "^7.0.0",
+    "rewire": "^4.0.1"
   },
   "dependencies": {
     "screwdriver-data-schema": "^18.39.2"

--- a/test/lib/getSrcForJoin.test.js
+++ b/test/lib/getSrcForJoin.test.js
@@ -3,7 +3,11 @@
 const assert = require('chai').assert;
 const getSrcForJoin = require('../../lib/getSrcForJoin');
 const WORKFLOW = require('../data/join-workflow');
+const rewire = require('rewire');
 
+const rewireGetSrcForJoin = rewire('../../lib/getSrcForJoin');
+
+/* eslint-disable no-underscore-dangle */
 describe('getSrcForJoin', () => {
     it('should throw if job not provided', () => {
         assert.throws(() => getSrcForJoin(WORKFLOW, {}),
@@ -20,5 +24,61 @@ describe('getSrcForJoin', () => {
         ]);
         // return empty arry if it's not a join job
         assert.deepEqual(getSrcForJoin(WORKFLOW, { jobName: 'bar' }), []);
+    });
+});
+
+describe('isPR', () => {
+    const isPR = rewireGetSrcForJoin.__get__('isPR');
+
+    it('sholud return true if job name has PR prefix', () => {
+        assert.isTrue(isPR('PR-1:testJobName'));
+    });
+
+    it('sholud return false if job name does not have PR prefix', () => {
+        assert.isFalse(isPR('testJobName'));
+    });
+});
+
+describe('findJobs', () => {
+    it('should find jobs when search job is joined job', () => {
+        const findJobs = rewireGetSrcForJoin.__get__('findJobs');
+        const destJobName = 'foo';
+
+        assert.deepEqual(findJobs(WORKFLOW, destJobName),
+            new Set([{ name: 'main', id: 1 }, { name: 'other_main', id: 2 }]));
+    });
+
+    it('should not find jobs when search job is not joined job', () => {
+        const findJobs = rewireGetSrcForJoin.__get__('findJobs');
+        const destJobName = 'bar';
+
+        assert.deepEqual(findJobs(WORKFLOW, destJobName), new Set());
+    });
+});
+
+describe('findPRJobs', () => {
+    it('should find jobs when search job is joined job', () => {
+        const findPRJobs = rewireGetSrcForJoin.__get__('findPRJobs');
+        const destJobName = 'PR-179:foo';
+
+        assert.deepEqual(findPRJobs(WORKFLOW, destJobName),
+            new Set([{ name: 'PR-179:main', id: 1 }, { name: 'PR-179:other_main', id: 2 }]));
+    });
+
+    it('should not find jobs when search job is not joined job', () => {
+        const findPRJobs = rewireGetSrcForJoin.__get__('findPRJobs');
+        const destJobName = 'PR-179:bar';
+
+        assert.deepEqual(findPRJobs(WORKFLOW, destJobName), new Set());
+    });
+});
+
+describe('getJoinJobs', () => {
+    it('should not return PR join jobs', () => {
+        const getJoinJobs = rewireGetSrcForJoin.__get__('getJoinJobs');
+        const destJobName = 'foo';
+
+        assert.deepEqual(getJoinJobs(WORKFLOW, destJobName),
+            new Set([{ name: 'main', id: 1 }, { name: 'other_main', id: 2 }]));
     });
 });

--- a/test/lib/getSrcForJoin.test.js
+++ b/test/lib/getSrcForJoin.test.js
@@ -40,8 +40,9 @@ describe('isPR', () => {
 });
 
 describe('findJobs', () => {
+    const findJobs = rewireGetSrcForJoin.__get__('findJobs');
+
     it('should find jobs when search job is joined job', () => {
-        const findJobs = rewireGetSrcForJoin.__get__('findJobs');
         const destJobName = 'foo';
 
         assert.deepEqual(findJobs(WORKFLOW, destJobName),
@@ -49,7 +50,6 @@ describe('findJobs', () => {
     });
 
     it('should not find jobs when search job is not joined job', () => {
-        const findJobs = rewireGetSrcForJoin.__get__('findJobs');
         const destJobName = 'bar';
 
         assert.deepEqual(findJobs(WORKFLOW, destJobName), new Set());
@@ -57,8 +57,9 @@ describe('findJobs', () => {
 });
 
 describe('findPRJobs', () => {
+    const findPRJobs = rewireGetSrcForJoin.__get__('findPRJobs');
+
     it('should find jobs when search job is joined job', () => {
-        const findPRJobs = rewireGetSrcForJoin.__get__('findPRJobs');
         const destJobName = 'PR-179:foo';
 
         assert.deepEqual(findPRJobs(WORKFLOW, destJobName),
@@ -66,7 +67,6 @@ describe('findPRJobs', () => {
     });
 
     it('should not find jobs when search job is not joined job', () => {
-        const findPRJobs = rewireGetSrcForJoin.__get__('findPRJobs');
         const destJobName = 'PR-179:bar';
 
         assert.deepEqual(findPRJobs(WORKFLOW, destJobName), new Set());
@@ -74,8 +74,9 @@ describe('findPRJobs', () => {
 });
 
 describe('getJoinJobs', () => {
-    it('should not return PR join jobs', () => {
-        const getJoinJobs = rewireGetSrcForJoin.__get__('getJoinJobs');
+    const getJoinJobs = rewireGetSrcForJoin.__get__('getJoinJobs');
+
+    it('should not return PR join jobs if it is not chainPR workflow', () => {
         const destJobName = 'foo';
 
         assert.deepEqual(getJoinJobs(WORKFLOW, destJobName),


### PR DESCRIPTION
## Context
Join job does not work when chainPR workflow.
PR jobs have `PR-{num}:` prefix, so jobs will not be found in `workflowGraph.edges.dest` objects.

## Objective
- We need to trim `PR-{num}:` prefix when searching jobs from workflowGraph objects in chainPR workflow.
- When returning join jobs, we need to add `PR-{num}:` prefix again.

## References
- Other PRs
API: https://github.com/screwdriver-cd/screwdriver/pull/1697

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
