### PR TITLE
feat(1710): support external join. BREAKING CHANGE: add new external join logic [4]

### DIFF
--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -30,6 +30,17 @@ const calculateNodes = (jobs, triggerFactory) => {
     return [...nodes].map(name => ({ name }));
 };
 
+const buildExternalEdge = async (root, children, edges, triggerFactory) => {
+    await Promise.all(children.map(async (dest) => {
+        edges.push({ src: root, dest });
+
+        const newRoot = dest;
+        const newChildren = await triggerFactory.getDestFromSrc(newRoot);
+
+        await buildExternalEdge(newRoot, newChildren, edges, triggerFactory);
+    }));
+};
+
 /**
  * Calculate edges of directed graph based on "requires" property of jobs
  * @method calculateEdges
@@ -63,29 +74,24 @@ const calculateEdges = async (jobs, triggerFactory, pipelineId) => {
                 }
                 edges.push(obj);
             });
+        }
 
-            // for backward compatibility
-            if (triggerFactory) {
-                const srcName = `sd@${pipelineId}:${jobname}`;
+        // for backward compatibility
+        if (triggerFactory) {
+            const srcName = `sd@${pipelineId}:${jobname}`;
 
-                // Calculate which downstream jobs are triggered BY current job
-                // Only need to take care of external triggers, since internal will be taken care automatically
-                const externalDownstreamOr = await triggerFactory.getDestFromSrc(`~${srcName}`);
-                const externalDownstreamAnd = await triggerFactory.getDestFromSrc(srcName);
-                const isExternalJoin = externalDownstreamAnd.size > 1;
+            // Calculate which downstream jobs are triggered BY current job
+            // Only need to take care of external triggers, since internal will be taken care automatically
 
-                externalDownstreamOr.forEach((dest) => {
-                    edges.push({ src: jobname, dest });
-                });
-                externalDownstreamAnd.forEach((dest) => {
-                    const obj = { src: jobname, dest };
+            const externalDownstreamOr = await triggerFactory.getDestFromSrc(`~${srcName}`);
+            const externalDownstreamAnd = await triggerFactory.getDestFromSrc(srcName);
 
-                    if (isExternalJoin) {
-                        obj.join = true;
-                    }
-                    edges.push(obj);
-                });
-            }
+            externalDownstreamOr.forEach((dest) => {
+                edges.push({ src: jobname, dest });
+            });
+
+            await buildExternalEdge(
+                jobname, externalDownstreamAnd, edges, triggerFactory);
         }
     }));
 

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -10,6 +10,26 @@ const filterNodeName = name =>
     (/^~(pr|commit|release|tag|sd@)/.test(name) ? name : name.replace('~', ''));
 
 /**
+ * Build external nodes for its downstream jobs, DFS to traverse its children
+ * @method buildExternalNodes
+ * @param  {String}         root           Source name. ex `sd@123:main`
+ * @param  {Array}          children       Array of downstream jobs. ex: [sd@456:test, sd@789:test]
+ * @param  {Set}            nodes          List of graph nodes
+ * @param  {TriggerFactory} triggerFactory triggerFactory to figure out its downstream jobs
+ * @return {Promise}  List of graph nodes
+ */
+const buildExternalNodes = async (root, children, nodes, triggerFactory) => {
+    await Promise.all(children.map(async (dest) => {
+        nodes.add(dest);
+
+        const newRoot = dest;
+        const newChildren = await triggerFactory.getDestFromSrc(newRoot);
+
+        await buildExternalNodes(newRoot, newChildren, nodes, triggerFactory);
+    }));
+};
+
+/**
  * Get the list of nodes for the graph
  * @method calculateNodes
  * @param  {Object}          jobs           Hash of job configs
@@ -18,36 +38,52 @@ const filterNodeName = name =>
  * @return {Array}           List of nodes (jobs)
  */
 const calculateNodes = async (jobs, triggerFactory, pipelineId) => {
-    console.log(triggerFactory);
     const nodes = new Set(['~pr', '~commit']);
 
-    Object.keys(jobs).forEach((name) => {
-        nodes.add(name);
-        if (Array.isArray(jobs[name].requires)) {
-            jobs[name].requires.forEach(n => nodes.add(filterNodeName(n)));
+    await Promise.all(Object.keys(jobs).map(async (jobName) => {
+        nodes.add(jobName);
+
+        // upstream nodes
+        if (Array.isArray(jobs[jobName].requires)) {
+            jobs[jobName].requires.forEach(n => nodes.add(filterNodeName(n)));
         }
-    });
+
+        // downstream nodes
+        const srcName = `sd@${pipelineId}:${jobName}`;
+
+        // Calculate which downstream jobs are triggered BY current job
+        // Only need to take care of external triggers, since internal will be taken care automatically
+        const externalDownstreamOr = await triggerFactory.getDestFromSrc(`~${srcName}`);
+        const externalDownstreamAnd = await triggerFactory.getDestFromSrc(srcName);
+
+        externalDownstreamOr.forEach((dest) => {
+            nodes.add(dest);
+        });
+
+        await buildExternalNodes(
+            jobName, externalDownstreamAnd, nodes, triggerFactory);
+    }));
 
     return [...nodes].map(name => ({ name }));
 };
 
 /**
  * Build external edges for its downstream jobs, DFS to traverse its children
- * @method buildExternalEdge
+ * @method buildExternalEdges
  * @param  {String}         root           Source name. ex `sd@123:main`
  * @param  {Array}          children       Array of downstream jobs. ex: [sd@456:test, sd@789:test]
- * @param  {Object}         edges          List of graph edges { src, dest }
+ * @param  {Array}          edges          List of graph edges { src, dest }
  * @param  {TriggerFactory} triggerFactory triggerFactory to figure out its downstream jobs
  * @return {Promise}  List of graph edges { src, dest }
  */
-const buildExternalEdge = async (root, children, edges, triggerFactory) => {
+const buildExternalEdges = async (root, children, edges, triggerFactory) => {
     await Promise.all(children.map(async (dest) => {
         edges.push({ src: root, dest });
 
         const newRoot = dest;
         const newChildren = await triggerFactory.getDestFromSrc(newRoot);
 
-        await buildExternalEdge(newRoot, newChildren, edges, triggerFactory);
+        await buildExternalEdges(newRoot, newChildren, edges, triggerFactory);
     }));
 };
 
@@ -62,8 +98,8 @@ const buildExternalEdge = async (root, children, edges, triggerFactory) => {
 const calculateEdges = async (jobs, triggerFactory, pipelineId) => {
     const edges = [];
 
-    await Promise.all(Object.keys(jobs).map(async (jobname) => {
-        const job = jobs[jobname];
+    await Promise.all(Object.keys(jobs).map(async (jobName) => {
+        const job = jobs[jobName];
 
         if (Array.isArray(job.requires)) {
             // Calculate which upstream jobs trigger the current job
@@ -74,10 +110,10 @@ const calculateEdges = async (jobs, triggerFactory, pipelineId) => {
             const isJoin = upstreamAnd.size > 1;
 
             upstreamOr.forEach((src) => {
-                edges.push({ src: filterNodeName(src), dest: jobname });
+                edges.push({ src: filterNodeName(src), dest: jobName });
             });
             upstreamAnd.forEach((src) => {
-                const obj = { src, dest: jobname };
+                const obj = { src, dest: jobName };
 
                 if (isJoin) {
                     obj.join = true;
@@ -86,23 +122,20 @@ const calculateEdges = async (jobs, triggerFactory, pipelineId) => {
             });
         }
 
-        // for backward compatibility
-        if (triggerFactory) {
-            const srcName = `sd@${pipelineId}:${jobname}`;
+        const srcName = `sd@${pipelineId}:${jobName}`;
 
-            // Calculate which downstream jobs are triggered BY current job
-            // Only need to take care of external triggers, since internal will be taken care automatically
+        // Calculate which downstream jobs are triggered BY current job
+        // Only need to take care of external triggers, since internal will be taken care automatically
 
-            const externalDownstreamOr = await triggerFactory.getDestFromSrc(`~${srcName}`);
-            const externalDownstreamAnd = await triggerFactory.getDestFromSrc(srcName);
+        const externalDownstreamOr = await triggerFactory.getDestFromSrc(`~${srcName}`);
+        const externalDownstreamAnd = await triggerFactory.getDestFromSrc(srcName);
 
-            externalDownstreamOr.forEach((dest) => {
-                edges.push({ src: jobname, dest });
-            });
+        externalDownstreamOr.forEach((dest) => {
+            edges.push({ src: jobName, dest });
+        });
 
-            await buildExternalEdge(
-                jobname, externalDownstreamAnd, edges, triggerFactory);
-        }
+        await buildExternalEdges(
+            jobName, externalDownstreamAnd, edges, triggerFactory);
     }));
 
     return edges;

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -40,6 +40,19 @@ const buildExternalNodes = async (root, children, nodes, triggerFactory) => {
 const calculateNodes = async (jobs, triggerFactory, pipelineId) => {
     const nodes = new Set(['~pr', '~commit']);
 
+    // for backward compatibility. TODO: remove this block later
+    if (!triggerFactory) {
+        Object.keys(jobs).forEach((name) => {
+            nodes.add(name);
+            if (Array.isArray(jobs[name].requires)) {
+                jobs[name].requires.forEach(n => nodes.add(filterNodeName(n)));
+            }
+        });
+
+        return [...nodes].map(name => ({ name }));
+    }
+
+    // new implementation. allow external join
     await Promise.all(Object.keys(jobs).map(async (jobName) => {
         nodes.add(jobName);
 
@@ -98,6 +111,39 @@ const buildExternalEdges = async (root, children, edges, triggerFactory) => {
 const calculateEdges = async (jobs, triggerFactory, pipelineId) => {
     const edges = [];
 
+    // for backward compatibility. TODO: remove this block later
+    if (!triggerFactory) {
+        Object.keys(jobs).forEach((j) => {
+            const job = jobs[j];
+            const dest = j;
+
+            if (Array.isArray(job.requires)) {
+                const specialTriggers = new Set(
+                    job.requires.filter(name => name.charAt(0) === '~'));
+                const normalTriggers = new Set(
+                    job.requires.filter(name => name.charAt(0) !== '~'));
+                const isJoin = normalTriggers.size > 1;
+
+                specialTriggers.forEach((src) => {
+                    edges.push({ src: filterNodeName(src), dest });
+                });
+
+                normalTriggers.forEach((src) => {
+                    const obj = { src, dest };
+
+                    if (isJoin) {
+                        obj.join = true;
+                    }
+
+                    edges.push(obj);
+                });
+            }
+        });
+
+        return edges;
+    }
+
+    // new implementation. allow external join
     await Promise.all(Object.keys(jobs).map(async (jobName) => {
         const job = jobs[jobName];
 

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -12,10 +12,12 @@ const filterNodeName = name =>
 /**
  * Get the list of nodes for the graph
  * @method calculateNodes
- * @param  {Object}       jobs Hash of job configs
- * @return {Array}             List of nodes (jobs)
+ * @param  {Object}          jobs Hash of job configs
+ * @param  {TriggerFactory}  triggerFactory Trigger Factory to find external triggers
+ * @return {Array}           List of nodes (jobs)
  */
-const calculateNodes = (jobs) => {
+const calculateNodes = (jobs, triggerFactory) => {
+    console.log(triggerFactory);
     const nodes = new Set(['~pr', '~commit']);
 
     Object.keys(jobs).forEach((name) => {
@@ -31,32 +33,52 @@ const calculateNodes = (jobs) => {
 /**
  * Calculate edges of directed graph based on "requires" property of jobs
  * @method calculateEdges
- * @param  {Object}       jobs Hash of job configurations
- * @return {Array}             List of graph edges { src, dest }
+ * @param  {Object}         jobs           Hash of job configurations
+ * @param  {TriggerFactory} triggerFactory Trigger Factory to find external triggers
+ * @param  {Number}         pipelineId     Id of the current pipeline
+ * @return {Array}          List of graph edges { src, dest }
  */
-const calculateEdges = (jobs) => {
+const calculateEdges = (jobs, triggerFactory, pipelineId) => {
+    console.log(triggerFactory);
     const edges = [];
 
     Object.keys(jobs).forEach((j) => {
         const job = jobs[j];
-        const dest = j;
+        const dest = job;
 
         if (Array.isArray(job.requires)) {
-            const specialTriggers = new Set(job.requires.filter(name => name.charAt(0) === '~'));
-            const normalTriggers = new Set(job.requires.filter(name => name.charAt(0) !== '~'));
-            const isJoin = normalTriggers.size > 1;
+            const isInternal = !name.startsWith('sd@') && !name.startsWith('~sd@');
+            const internalOrTriggers = new Set(job.requires.filter(name => isInternal && name.charAt(0) === '~'));
+            const internalAndTriggers = new Set(job.requires.filter(name => isInternal && name.charAt(0) !== '~'));
 
-            specialTriggers.forEach((src) => {
+            const srcName = `sd@${pipelineId}:${job}`;
+            const externalOrTriggers = await triggerFactory.getDestFromSrc(`~${srcName}`);
+            const externalAndTriggers = await triggerFactory.getDestFromSrc(srcName);
+
+            const isInternalJoin = internalAndTriggers.size > 1;
+            const isExternalJoin = externalAndTriggers.size > 1;
+            const isMixedJoin = isInternalJoin && isExternalJoin;
+
+            internalOrTriggers.forEach((src) => {
                 edges.push({ src: filterNodeName(src), dest });
             });
 
-            normalTriggers.forEach((src) => {
+            internalAndTriggers.forEach((src) => {
                 const obj = { src, dest };
 
-                if (isJoin) {
+                if (isInternalJoin || isMixedJoin) {
                     obj.join = true;
                 }
 
+                edges.push(obj);
+            });
+
+            externalAndTriggers.forEach((dest) => {
+                const obj = { src: job, dest };
+
+                if (!dest.startsWith('~')) {
+                    obj.join = true;
+                }
                 edges.push(obj);
             });
         }
@@ -68,21 +90,22 @@ const calculateEdges = (jobs) => {
 /**
  * Given a pipeline config, return a directed graph configuration that describes the workflow
  * @method getWorkflow
- * @param  {Object}    pipelineConfig                 A Pipeline Config
- * @param  {Object}    pipelineConfig.jobs            Hash of job configs
+ * @param  {Object}    pipelineConfig           A Pipeline Config
+ * @param  {Object}    pipelineConfig.jobs      Hash of job configs
+ * @param  {TriggerFactory} triggerFactory      Trigger Factory to find external triggers
+ * @param  {Number}    pipelineId               Id of the current pipeline
  * @return {Object}                             List of nodes and edges { nodes, edges }
  */
-const getWorkflow = (pipelineConfig) => {
+const getWorkflow = (pipelineConfig, triggerFactory, pipelineId) => {
     const jobConfig = pipelineConfig.jobs;
-    let edges = [];
 
     if (!jobConfig) {
         throw new Error('No Job config provided');
     }
+    const edges = calculateEdges(jobConfig, triggerFactory, pipelineId);
+    const nodes = calculateNodes(jobConfig, triggerFactory, pipelineId);
 
-    edges = calculateEdges(jobConfig);
-
-    return { nodes: calculateNodes(jobConfig), edges };
+    return { nodes, edges };
 };
 
 module.exports = getWorkflow;

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -12,11 +12,12 @@ const filterNodeName = name =>
 /**
  * Get the list of nodes for the graph
  * @method calculateNodes
- * @param  {Object}          jobs Hash of job configs
+ * @param  {Object}          jobs           Hash of job configs
  * @param  {TriggerFactory}  triggerFactory Trigger Factory to find external triggers
+ * @param  {Number}          pipelineId     Id of the current pipeline
  * @return {Array}           List of nodes (jobs)
  */
-const calculateNodes = (jobs, triggerFactory) => {
+const calculateNodes = async (jobs, triggerFactory, pipelineId) => {
     console.log(triggerFactory);
     const nodes = new Set(['~pr', '~commit']);
 
@@ -30,6 +31,15 @@ const calculateNodes = (jobs, triggerFactory) => {
     return [...nodes].map(name => ({ name }));
 };
 
+/**
+ * Build external edges for its downstream jobs, DFS to traverse its children
+ * @method buildExternalEdge
+ * @param  {String}         root           Source name. ex `sd@123:main`
+ * @param  {Array}          children       Array of downstream jobs. ex: [sd@456:test, sd@789:test]
+ * @param  {Object}         edges          List of graph edges { src, dest }
+ * @param  {TriggerFactory} triggerFactory triggerFactory to figure out its downstream jobs
+ * @return {Promise}  List of graph edges { src, dest }
+ */
 const buildExternalEdge = async (root, children, edges, triggerFactory) => {
     await Promise.all(children.map(async (dest) => {
         edges.push({ src: root, dest });
@@ -101,11 +111,11 @@ const calculateEdges = async (jobs, triggerFactory, pipelineId) => {
 /**
  * Given a pipeline config, return a directed graph configuration that describes the workflow
  * @method getWorkflow
- * @param  {Object}    pipelineConfig           A Pipeline Config
- * @param  {Object}    pipelineConfig.jobs      Hash of job configs
- * @param  {TriggerFactory} triggerFactory      Trigger Factory to find external triggers
- * @param  {Number}    pipelineId               Id of the current pipeline
- * @return {Object}                             List of nodes and edges { nodes, edges }
+ * @param  {Object}         pipelineConfig          A Pipeline Config
+ * @param  {Object}         pipelineConfig.jobs     Hash of job configs
+ * @param  {TriggerFactory} triggerFactory          Trigger Factory to find external triggers
+ * @param  {Number}         pipelineId              Id of the current pipeline
+ * @return {Object}         List of nodes and edges {nodes, edges}
  */
 const getWorkflow = async (pipelineConfig, triggerFactory, pipelineId) => {
     const jobConfig = pipelineConfig.jobs;
@@ -113,8 +123,8 @@ const getWorkflow = async (pipelineConfig, triggerFactory, pipelineId) => {
     if (!jobConfig) {
         throw new Error('No Job config provided');
     }
+    const nodes = await calculateNodes(jobConfig, triggerFactory, pipelineId);
     const edges = await calculateEdges(jobConfig, triggerFactory, pipelineId);
-    const nodes = calculateNodes(jobConfig, triggerFactory, pipelineId);
 
     return { nodes, edges };
 };

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -12,20 +12,18 @@ const filterNodeName = name =>
 /**
  * Build external nodes for its downstream jobs, DFS to traverse its children
  * @method buildExternalNodes
- * @param  {String}         root           Source name. ex `sd@123:main`
  * @param  {Array}          children       Array of downstream jobs. ex: [sd@456:test, sd@789:test]
  * @param  {Set}            nodes          List of graph nodes
  * @param  {TriggerFactory} triggerFactory triggerFactory to figure out its downstream jobs
  * @return {Promise}  List of graph nodes
  */
-const buildExternalNodes = async (root, children, nodes, triggerFactory) => {
+const buildExternalNodes = async (children, nodes, triggerFactory) => {
     await Promise.all(children.map(async (dest) => {
         nodes.add(dest);
 
-        const newRoot = dest;
-        const newChildren = await triggerFactory.getDestFromSrc(newRoot);
+        const newChildren = await triggerFactory.getDestFromSrc(dest);
 
-        await buildExternalNodes(newRoot, newChildren, nodes, triggerFactory);
+        await buildExternalNodes(newChildren, nodes, triggerFactory);
     }));
 };
 
@@ -74,7 +72,7 @@ const calculateNodes = async (jobs, triggerFactory, pipelineId) => {
         });
 
         await buildExternalNodes(
-            jobName, externalDownstreamAnd, nodes, triggerFactory);
+            externalDownstreamAnd, nodes, triggerFactory);
     }));
 
     return [...nodes].map(name => ({ name }));
@@ -83,9 +81,9 @@ const calculateNodes = async (jobs, triggerFactory, pipelineId) => {
 /**
  * Build external edges for its downstream jobs, DFS to traverse its children
  * @method buildExternalEdges
- * @param  {String}         root           Source name. ex `sd@123:main`
- * @param  {Array}          children       Array of downstream jobs. ex: [sd@456:test, sd@789:test]
- * @param  {Array}          edges          List of graph edges { src, dest }
+ * @param  {String}         root           Source name. (e.g. main or sd@111:main)
+ * @param  {Array}          children       Array of downstream jobs. (e.g.: [sd@456:test, sd@789:test])
+ * @param  {Array}          edges          List of graph edges in the form { src, dest }
  * @param  {TriggerFactory} triggerFactory triggerFactory to figure out its downstream jobs
  * @return {Promise}  List of graph edges { src, dest }
  */
@@ -93,10 +91,9 @@ const buildExternalEdges = async (root, children, edges, triggerFactory) => {
     await Promise.all(children.map(async (dest) => {
         edges.push({ src: root, dest });
 
-        const newRoot = dest;
-        const newChildren = await triggerFactory.getDestFromSrc(newRoot);
+        const newChildren = await triggerFactory.getDestFromSrc(dest);
 
-        await buildExternalEdges(newRoot, newChildren, edges, triggerFactory);
+        await buildExternalEdges(dest, newChildren, edges, triggerFactory);
     }));
 };
 
@@ -172,7 +169,6 @@ const calculateEdges = async (jobs, triggerFactory, pipelineId) => {
 
         // Calculate which downstream jobs are triggered BY current job
         // Only need to take care of external triggers, since internal will be taken care automatically
-
         const externalDownstreamOr = await triggerFactory.getDestFromSrc(`~${srcName}`);
         const externalDownstreamAnd = await triggerFactory.getDestFromSrc(srcName);
 
@@ -180,6 +176,7 @@ const calculateEdges = async (jobs, triggerFactory, pipelineId) => {
             edges.push({ src: jobName, dest });
         });
 
+        // Handle join case
         await buildExternalEdges(
             jobName, externalDownstreamAnd, edges, triggerFactory);
     }));

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -38,51 +38,56 @@ const calculateNodes = (jobs, triggerFactory) => {
  * @param  {Number}         pipelineId     Id of the current pipeline
  * @return {Array}          List of graph edges { src, dest }
  */
-const calculateEdges = (jobs, triggerFactory, pipelineId) => {
-    console.log(triggerFactory);
+const calculateEdges = async (jobs, triggerFactory, pipelineId) => {
     const edges = [];
 
-    Object.keys(jobs).forEach((j) => {
-        const job = jobs[j];
-        const dest = job;
+    await Promise.all(Object.keys(jobs).map(async (jobname) => {
+        const job = jobs[jobname];
 
         if (Array.isArray(job.requires)) {
-            const isInternal = !name.startsWith('sd@') && !name.startsWith('~sd@');
-            const internalOrTriggers = new Set(job.requires.filter(name => isInternal && name.charAt(0) === '~'));
-            const internalAndTriggers = new Set(job.requires.filter(name => isInternal && name.charAt(0) !== '~'));
+            // Calculate which upstream jobs trigger the current job
+            const upstreamOr = new Set(
+                job.requires.filter(name => name.charAt(0) === '~'));
+            const upstreamAnd = new Set(
+                job.requires.filter(name => name.charAt(0) !== '~'));
+            const isJoin = upstreamAnd.size > 1;
 
-            const srcName = `sd@${pipelineId}:${job}`;
-            const externalOrTriggers = await triggerFactory.getDestFromSrc(`~${srcName}`);
-            const externalAndTriggers = await triggerFactory.getDestFromSrc(srcName);
-
-            const isInternalJoin = internalAndTriggers.size > 1;
-            const isExternalJoin = externalAndTriggers.size > 1;
-            const isMixedJoin = isInternalJoin && isExternalJoin;
-
-            internalOrTriggers.forEach((src) => {
-                edges.push({ src: filterNodeName(src), dest });
+            upstreamOr.forEach((src) => {
+                edges.push({ src: filterNodeName(src), dest: jobname });
             });
+            upstreamAnd.forEach((src) => {
+                const obj = { src, dest: jobname };
 
-            internalAndTriggers.forEach((src) => {
-                const obj = { src, dest };
-
-                if (isInternalJoin || isMixedJoin) {
-                    obj.join = true;
-                }
-
-                edges.push(obj);
-            });
-
-            externalAndTriggers.forEach((dest) => {
-                const obj = { src: job, dest };
-
-                if (!dest.startsWith('~')) {
+                if (isJoin) {
                     obj.join = true;
                 }
                 edges.push(obj);
             });
+
+            // for backward compatibility
+            if (triggerFactory) {
+                const srcName = `sd@${pipelineId}:${jobname}`;
+
+                // Calculate which downstream jobs are triggered BY current job
+                // Only need to take care of external triggers, since internal will be taken care automatically
+                const externalDownstreamOr = await triggerFactory.getDestFromSrc(`~${srcName}`);
+                const externalDownstreamAnd = await triggerFactory.getDestFromSrc(srcName);
+                const isExternalJoin = externalDownstreamAnd.size > 1;
+
+                externalDownstreamOr.forEach((dest) => {
+                    edges.push({ src: jobname, dest });
+                });
+                externalDownstreamAnd.forEach((dest) => {
+                    const obj = { src: jobname, dest };
+
+                    if (isExternalJoin) {
+                        obj.join = true;
+                    }
+                    edges.push(obj);
+                });
+            }
         }
-    });
+    }));
 
     return edges;
 };
@@ -96,13 +101,13 @@ const calculateEdges = (jobs, triggerFactory, pipelineId) => {
  * @param  {Number}    pipelineId               Id of the current pipeline
  * @return {Object}                             List of nodes and edges { nodes, edges }
  */
-const getWorkflow = (pipelineConfig, triggerFactory, pipelineId) => {
+const getWorkflow = async (pipelineConfig, triggerFactory, pipelineId) => {
     const jobConfig = pipelineConfig.jobs;
 
     if (!jobConfig) {
         throw new Error('No Job config provided');
     }
-    const edges = calculateEdges(jobConfig, triggerFactory, pipelineId);
+    const edges = await calculateEdges(jobConfig, triggerFactory, pipelineId);
     const nodes = calculateNodes(jobConfig, triggerFactory, pipelineId);
 
     return { nodes, edges };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^7.0.0",
-    "rewire": "^4.0.1"
+    "rewire": "^4.0.1",
+    "sinon": "^7.5.0"
   },
   "dependencies": {
     "screwdriver-data-schema": "^18.39.2"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "screwdriver-data-schema": "^18.39.2"
+    "screwdriver-data-schema": "^19.0.0"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-workflow-parser",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Parses and converts pipeline configuration into a workflow",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chai": "^4.1.2",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^7.0.0",
+    "jenkins-mocha": "^8.0.0",
     "rewire": "^4.0.1",
     "sinon": "^7.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-workflow-parser",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Parses and converts pipeline configuration into a workflow",
   "main": "index.js",
   "scripts": {

--- a/test/data/expected-external-complex.json
+++ b/test/data/expected-external-complex.json
@@ -1,0 +1,32 @@
+{
+    "nodes": [
+        { "name": "~pr" },
+        { "name": "~commit" },
+        { "name": "A" },
+        { "name": "B" },
+        { "name": "C" },
+        { "name": "sd@222:external-level2" },
+        { "name": "sd@444:external-level2" },
+        { "name": "sd@555:external-level2" },
+        { "name": "~sd@888:external-level2" },
+        { "name": "~sd@777:external-level1" },
+        { "name": "sd@111:external-level1" },
+        { "name": "sd@333:external-level1" },
+        { "name": "sd@666:external-level3" }
+    ],
+    "edges": [
+        { "src": "A", "dest": "B" },
+        { "src": "~sd@888:external-level2", "dest": "C" },
+        { "src": "B", "dest": "C", "join": true },
+        { "src": "sd@222:external-level2", "dest": "C", "join": true },
+        { "src": "sd@444:external-level2", "dest": "C", "join": true },
+        { "src": "sd@555:external-level2", "dest": "C", "join": true },
+        { "src": "A", "dest": "~sd@777:external-level1" },
+        { "src": "A", "dest": "sd@111:external-level1" },
+        { "src": "A", "dest": "sd@333:external-level1" },
+        { "src": "sd@111:external-level1", "dest": "sd@222:external-level2" },
+        { "src": "sd@333:external-level1", "dest": "sd@444:external-level2" },
+        { "src": "sd@333:external-level1", "dest": "sd@555:external-level2" },
+        { "src": "sd@555:external-level2", "dest": "sd@666:external-level3" }
+    ]
+}

--- a/test/data/expected-external.json
+++ b/test/data/expected-external.json
@@ -5,6 +5,7 @@
         { "name": "main" },
         { "name": "foo" },
         { "name": "bar" },
+        { "name": "sd@111:baz" },
         { "name": "~sd@1234:foo" }
     ],
     "edges": [
@@ -12,6 +13,7 @@
         { "src": "~commit", "dest": "main" },
         { "src": "main", "dest": "foo" },
         { "src": "~sd@1234:foo", "dest": "bar" },
-        { "src": "foo", "dest": "bar" }
+        { "src": "foo", "dest": "bar", "join": true },
+        { "src": "sd@111:baz", "dest": "bar", "join": true }
     ]
 }

--- a/test/data/requires-workflow-exttrigger.json
+++ b/test/data/requires-workflow-exttrigger.json
@@ -2,6 +2,6 @@
     "jobs": {
         "main": { "requires": ["~pr", "~commit"] },
         "foo": { "requires": ["main"] },
-        "bar": { "requires": ["foo", "~sd@1234:foo"] }
+        "bar": { "requires": ["foo", "sd@111:baz", "~sd@1234:foo"] }
     }
 }

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -4,6 +4,7 @@ const assert = require('chai').assert;
 const getNextJobs = require('../../lib/getNextJobs');
 const WORKFLOW = require('../data/expected-output');
 const EXTERNAL_WORKFLOW = require('../data/expected-external');
+const EXTERNAL_COMPLEX_WORKFLOW = require('../data/expected-external-complex');
 
 describe('getNextJobs', () => {
     it('should throw if trigger not provided', () => {
@@ -113,5 +114,18 @@ describe('getNextJobs', () => {
         // trigger by a pull request on "bar-foo-prod" branch
         assert.deepEqual(getNextJobs(specificBranchWorkflow, { trigger: '~pr:bar-foo-prod',
             prNum: '123' }), ['PR-123:f', 'PR-123:g']);
+    });
+
+    it('should figure out what jobs start next with external workflow', () => {
+        /* A - B                                                   - C
+             \ sd@111:external-level1 ->  sd@222:external-level2    /
+             \ sd@333:external-level1 ->  sd@444:external-level2    /
+                                          sd@555:external-level2    /
+             \ ~sd@777:external-level1 -> ~sd@888:external-level2   /
+        */
+        assert.deepEqual(getNextJobs(EXTERNAL_COMPLEX_WORKFLOW, { trigger: 'A' }),
+            ['B', '~sd@777:external-level1', 'sd@111:external-level1', 'sd@333:external-level1']);
+        assert.deepEqual(getNextJobs(EXTERNAL_COMPLEX_WORKFLOW,
+            { trigger: 'B' }), ['C']);
     });
 });

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -3,6 +3,7 @@
 const assert = require('chai').assert;
 const getNextJobs = require('../../lib/getNextJobs');
 const WORKFLOW = require('../data/expected-output');
+const EXTERNAL_WORKFLOW = require('../data/expected-external');
 
 describe('getNextJobs', () => {
     it('should throw if trigger not provided', () => {
@@ -57,6 +58,10 @@ describe('getNextJobs', () => {
             trigger: 'PR-123:bar',
             chainPR: true
         }), []);
+    });
+
+    it('should figure out what jobs start next with parallel workflow with external', () => {
+        assert.deepEqual(getNextJobs(EXTERNAL_WORKFLOW, { trigger: 'sd@111:baz' }), ['bar']);
     });
 
     it('should figure out what jobs start next with parallel workflow', () => {

--- a/test/lib/getSrcForJoin.test.js
+++ b/test/lib/getSrcForJoin.test.js
@@ -4,6 +4,7 @@ const assert = require('chai').assert;
 const getSrcForJoin = require('../../lib/getSrcForJoin');
 const WORKFLOW = require('../data/join-workflow');
 const EXTERNAL_WORKFLOW = require('../data/expected-external');
+const EXTERNAL_COMPLEX_WORKFLOW = require('../data/expected-external-complex');
 const rewire = require('rewire');
 
 const rewireGetSrcForJoin = rewire('../../lib/getSrcForJoin');
@@ -34,6 +35,21 @@ describe('getSrcForJoin', () => {
         }), [
             { name: 'foo' },
             { name: 'sd@111:baz' }
+        ]);
+    });
+
+    it('should figure out what src for the job for a complex workflow', () => {
+        // src nodes for join job
+        assert.deepEqual(getSrcForJoin(EXTERNAL_COMPLEX_WORKFLOW,
+            { jobName: 'A' }), []);
+        assert.deepEqual(getSrcForJoin(EXTERNAL_COMPLEX_WORKFLOW,
+            { jobName: 'B' }), []);
+        assert.deepEqual(getSrcForJoin(EXTERNAL_COMPLEX_WORKFLOW,
+            { jobName: 'C' }), [
+            { name: 'B' },
+            { name: 'sd@222:external-level2' },
+            { name: 'sd@444:external-level2' },
+            { name: 'sd@555:external-level2' }
         ]);
     });
 });

--- a/test/lib/getSrcForJoin.test.js
+++ b/test/lib/getSrcForJoin.test.js
@@ -3,6 +3,7 @@
 const assert = require('chai').assert;
 const getSrcForJoin = require('../../lib/getSrcForJoin');
 const WORKFLOW = require('../data/join-workflow');
+const EXTERNAL_WORKFLOW = require('../data/expected-external');
 const rewire = require('rewire');
 
 const rewireGetSrcForJoin = rewire('../../lib/getSrcForJoin');
@@ -24,6 +25,16 @@ describe('getSrcForJoin', () => {
         ]);
         // return empty arry if it's not a join job
         assert.deepEqual(getSrcForJoin(WORKFLOW, { jobName: 'bar' }), []);
+    });
+
+    it('should figure out what src for the job if it is a join and external job', () => {
+        // src nodes for join job
+        assert.deepEqual(getSrcForJoin(EXTERNAL_WORKFLOW, {
+            jobName: 'bar'
+        }), [
+            { name: 'foo' },
+            { name: 'sd@111:baz' }
+        ]);
     });
 });
 
@@ -47,6 +58,13 @@ describe('findJobs', () => {
 
         assert.deepEqual(findJobs(WORKFLOW, destJobName),
             new Set([{ name: 'main', id: 1 }, { name: 'other_main', id: 2 }]));
+    });
+
+    it('should find jobs when search job is joined job and is external', () => {
+        const destJobName = 'bar';
+
+        assert.deepEqual(findJobs(EXTERNAL_WORKFLOW, destJobName),
+            new Set([{ name: 'foo' }, { name: 'sd@111:baz' }]));
     });
 
     it('should not find jobs when search job is not joined job', () => {

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -13,7 +13,7 @@ const EXPECTED_EXTERNAL_COMPLEX = require('../data/expected-external-complex');
 
 NO_EDGES.edges = [];
 
-describe('getWorkflow', () => {
+describe.only('getWorkflow', () => {
     const triggerFactoryMock = {
         getDestFromSrc: sinon.stub().resolves([])
     };

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -15,22 +15,27 @@ const EXPECTED_EXTERNAL = require('../data/expected-external');
 NO_EDGES.edges = [];
 
 describe('getWorkflow', () => {
-    it('should throw if it is not given correct input', () => {
-        assert.throws(() => getWorkflow({ config: {} }),
-            Error, 'No Job config provided');
+    it('should throw if it is not given correct input', async () => {
+        try {
+            await getWorkflow({ config: {} });
+        } catch (e) {
+            console.log(e);
+            assert.equal(e.message, 'No Job config provided');
+        }
     });
 
-    it('should convert a config with job-requires workflow to directed graph', () => {
-        assert.deepEqual(getWorkflow(REQUIRES_WORKFLOW),
-            EXPECTED_OUTPUT, 'requires-style workflow');
-        assert.deepEqual(getWorkflow(LEGACY_AND_REQUIRES_WORKFLOW),
-            EXPECTED_OUTPUT, 'both legacy and non-legacy workflows');
-        assert.deepEqual(getWorkflow(EXTERNAL_TRIGGER),
-            EXPECTED_EXTERNAL, 'requires-style workflow with external trigger');
+    it('should convert a config with job-requires workflow to directed graph', async () => {
+        const requires = await getWorkflow(REQUIRES_WORKFLOW);
+        const legacyRequires = await getWorkflow(LEGACY_AND_REQUIRES_WORKFLOW);
+        const external = await getWorkflow(EXTERNAL_TRIGGER);
+
+        assert.deepEqual(requires, EXPECTED_OUTPUT);
+        assert.deepEqual(legacyRequires, EXPECTED_OUTPUT);
+        assert.deepEqual(external, EXPECTED_EXTERNAL);
     });
 
-    it('should handle detatched jobs', () => {
-        const result = getWorkflow({
+    it('should handle detatched jobs', async () => {
+        const result = await getWorkflow({
             jobs: {
                 foo: {},
                 bar: { requires: ['foo'] }
@@ -48,8 +53,8 @@ describe('getWorkflow', () => {
         });
     });
 
-    it('should handle logical OR requires', () => {
-        const result = getWorkflow({
+    it('should handle logical OR requires', async () => {
+        const result = await getWorkflow({
             jobs: {
                 foo: { requires: ['~commit'] },
                 A: { requires: ['foo'] },
@@ -79,8 +84,8 @@ describe('getWorkflow', () => {
         });
     });
 
-    it('should handle logical OR and logial AND requires', () => {
-        const result = getWorkflow({
+    it('should handle logical OR and logial AND requires', async () => {
+        const result = await getWorkflow({
             jobs: {
                 foo: { requires: ['~commit'] },
                 A: { requires: ['foo'] },
@@ -114,8 +119,8 @@ describe('getWorkflow', () => {
         });
     });
 
-    it('should dedupe requires', () => {
-        const result = getWorkflow({
+    it('should dedupe requires', async () => {
+        const result = await getWorkflow({
             jobs: {
                 foo: { requires: ['A', 'A', 'A'] },
                 A: {}
@@ -135,8 +140,8 @@ describe('getWorkflow', () => {
         });
     });
 
-    it('should handle joins', () => {
-        const result = getWorkflow({
+    it('should handle joins', async () => {
+        const result = await getWorkflow({
             jobs: {
                 foo: { },
                 bar: { requires: ['foo'] },

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -9,6 +9,7 @@ const EXTERNAL_TRIGGER = require('../data/requires-workflow-exttrigger');
 const EXPECTED_OUTPUT = require('../data/expected-output');
 const NO_EDGES = Object.assign({}, EXPECTED_OUTPUT);
 const EXPECTED_EXTERNAL = require('../data/expected-external');
+const EXPECTED_EXTERNAL_COMPLEX = require('../data/expected-external-complex');
 
 NO_EDGES.edges = [];
 
@@ -210,37 +211,6 @@ describe('getWorkflow', () => {
             }
         }, triggerFactoryMock, 123);
 
-        assert.deepEqual(result, {
-            nodes: [
-                { name: '~pr' },
-                { name: '~commit' },
-                { name: 'A' },
-                { name: 'B' },
-                { name: 'C' },
-                { name: 'sd@222:external-level2' },
-                { name: 'sd@444:external-level2' },
-                { name: 'sd@555:external-level2' },
-                { name: '~sd@888:external-level2' },
-                { name: '~sd@777:external-level1' },
-                { name: 'sd@111:external-level1' },
-                { name: 'sd@333:external-level1' },
-                { name: 'sd@666:external-level3' }
-            ],
-            edges: [
-                { src: 'A', dest: 'B' },
-                { src: '~sd@888:external-level2', dest: 'C' },
-                { src: 'B', dest: 'C', join: true },
-                { src: 'sd@222:external-level2', dest: 'C', join: true },
-                { src: 'sd@444:external-level2', dest: 'C', join: true },
-                { src: 'sd@555:external-level2', dest: 'C', join: true },
-                { src: 'A', dest: '~sd@777:external-level1' },
-                { src: 'A', dest: 'sd@111:external-level1' },
-                { src: 'A', dest: 'sd@333:external-level1' },
-                { src: 'sd@111:external-level1', dest: 'sd@222:external-level2' },
-                { src: 'sd@333:external-level1', dest: 'sd@444:external-level2' },
-                { src: 'sd@333:external-level1', dest: 'sd@555:external-level2' },
-                { src: 'sd@555:external-level2', dest: 'sd@666:external-level3' }
-            ]
-        });
+        assert.deepEqual(result, EXPECTED_EXTERNAL_COMPLEX);
     });
 });

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -174,6 +174,7 @@ describe('getWorkflow', () => {
         /* A -> B                                                   --> C
                 sd@111:external-level1 -> sd@222:external-level2
                 sd@333:external-level1 -> sd@444:external-level2
+                                          sd@555:external-level2
         */
 
         triggerFactoryMock.getDestFromSrc.withArgs('sd@123:A').resolves([
@@ -184,7 +185,10 @@ describe('getWorkflow', () => {
             'sd@222:external-level2'
         ]);
         triggerFactoryMock.getDestFromSrc.withArgs('sd@333:external-level1').resolves([
-            'sd@444:external-level2'
+            'sd@444:external-level2', 'sd@555:external-level2'
+        ]);
+        triggerFactoryMock.getDestFromSrc.withArgs('sd@555:external-level2').resolves([
+            'sd@666:external-level3'
         ]);
 
         const result = await getWorkflow({
@@ -220,7 +224,9 @@ describe('getWorkflow', () => {
                 { src: 'A', dest: 'sd@111:external-level1' },
                 { src: 'A', dest: 'sd@333:external-level1' },
                 { src: 'sd@111:external-level1', dest: 'sd@222:external-level2' },
-                { src: 'sd@333:external-level1', dest: 'sd@444:external-level2' }
+                { src: 'sd@333:external-level1', dest: 'sd@444:external-level2' },
+                { src: 'sd@333:external-level1', dest: 'sd@555:external-level2' },
+                { src: 'sd@555:external-level2', dest: 'sd@666:external-level3' }
             ]
         });
     });

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -1,13 +1,11 @@
 'use strict';
 
 const assert = require('chai').assert;
+const sinon = require('sinon');
 const getWorkflow = require('../../lib/getWorkflow');
-
 const REQUIRES_WORKFLOW = require('../data/requires-workflow');
 const LEGACY_AND_REQUIRES_WORKFLOW = Object.assign({}, REQUIRES_WORKFLOW);
-
 const EXTERNAL_TRIGGER = require('../data/requires-workflow-exttrigger');
-
 const EXPECTED_OUTPUT = require('../data/expected-output');
 const NO_EDGES = Object.assign({}, EXPECTED_OUTPUT);
 const EXPECTED_EXTERNAL = require('../data/expected-external');
@@ -15,6 +13,10 @@ const EXPECTED_EXTERNAL = require('../data/expected-external');
 NO_EDGES.edges = [];
 
 describe('getWorkflow', () => {
+    const triggerFactoryMock = {
+        getDestFromSrc: sinon.stub().resolves([])
+    };
+
     it('should throw if it is not given correct input', async () => {
         try {
             await getWorkflow({ config: {} });
@@ -164,6 +166,61 @@ describe('getWorkflow', () => {
                 { src: 'foo', dest: 'baz' },
                 { src: 'bar', dest: 'bax', join: true },
                 { src: 'baz', dest: 'bax', join: true }
+            ]
+        });
+    });
+
+    it('should handle external upstream & downstream join', async () => {
+        /* A -> B                                                   --> C
+                sd@111:external-level1 -> sd@222:external-level2
+                sd@333:external-level1 -> sd@444:external-level2
+        */
+
+        triggerFactoryMock.getDestFromSrc.withArgs('sd@123:A').resolves([
+            'sd@111:external-level1',
+            'sd@333:external-level1'
+        ]);
+        triggerFactoryMock.getDestFromSrc.withArgs('sd@111:external-level1').resolves([
+            'sd@222:external-level2'
+        ]);
+        triggerFactoryMock.getDestFromSrc.withArgs('sd@333:external-level1').resolves([
+            'sd@444:external-level2'
+        ]);
+
+        const result = await getWorkflow({
+            jobs: {
+                A: { },
+                B: { requires: ['A'] },
+                C: { requires: [
+                    'B',
+                    'sd@222:external-level2',
+                    'sd@444:external-level2'
+                ] }
+            }
+        }, triggerFactoryMock, 123);
+
+        console.log(result);
+        assert.deepEqual(result, {
+            nodes: [
+                { name: '~pr' },
+                { name: '~commit' },
+                { name: 'A' },
+                { name: 'B' },
+                { name: 'C' },
+                { name: 'sd@111:external-level1' },
+                { name: 'sd@222:external-level2' },
+                { name: 'sd@333:external-level1' },
+                { name: 'sd@444:external-level2' }
+            ],
+            edges: [
+                { src: 'A', dest: 'B' },
+                { src: 'B', dest: 'C', join: true },
+                { src: 'sd@222:external-level2', dest: 'C', join: true },
+                { src: 'sd@444:external-level2', dest: 'C', join: true },
+                { src: 'A', dest: 'sd@111:external-level1' },
+                { src: 'A', dest: 'sd@333:external-level1' },
+                { src: 'sd@111:external-level1', dest: 'sd@222:external-level2' },
+                { src: 'sd@333:external-level1', dest: 'sd@444:external-level2' }
             ]
         });
     });

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -13,7 +13,7 @@ const EXPECTED_EXTERNAL_COMPLEX = require('../data/expected-external-complex');
 
 NO_EDGES.edges = [];
 
-describe.only('getWorkflow', () => {
+describe('getWorkflow', () => {
     const triggerFactoryMock = {
         getDestFromSrc: sinon.stub().resolves([])
     };

--- a/test/lib/hasCycle.test.js
+++ b/test/lib/hasCycle.test.js
@@ -31,6 +31,44 @@ describe('hasCyles', () => {
         assert.isTrue(hasCycle(workflow));
     });
 
+    it('should return true if a workflow has a cycle with external', () => {
+        const externalWorkflow = {
+            nodes: [
+                { name: '~pr' },
+                { name: '~commit' },
+                { name: 'A' },
+                { name: 'B' },
+                { name: 'C' },
+                { name: 'sd@222:external-level2' },
+                { name: 'sd@444:external-level2' },
+                { name: 'sd@555:external-level2' },
+                { name: '~sd@888:external-level2' },
+                { name: '~sd@777:external-level1' },
+                { name: 'sd@111:external-level1' },
+                { name: 'sd@333:external-level1' },
+                { name: 'sd@666:external-level3' }
+            ],
+            edges: [
+                { src: 'A', dest: 'B' },
+                { src: '~sd@888:external-level2', dest: 'C' },
+                { src: 'B', dest: 'C', join: true },
+                { src: 'sd@222:external-level2', dest: 'C', join: true },
+                { src: 'sd@444:external-level2', dest: 'C', join: true },
+                { src: 'sd@555:external-level2', dest: 'C', join: true },
+                { src: 'A', dest: '~sd@777:external-level1' },
+                { src: 'A', dest: 'sd@111:external-level1' },
+                { src: 'A', dest: 'sd@333:external-level1' },
+                { src: 'sd@111:external-level1', dest: 'sd@222:external-level2' },
+                { src: 'sd@333:external-level1', dest: 'sd@444:external-level2' },
+                { src: 'sd@333:external-level1', dest: 'sd@555:external-level2' },
+                { src: 'sd@555:external-level2', dest: 'sd@666:external-level3' },
+                { src: 'sd@555:external-level2', dest: 'A' }
+            ]
+        };
+
+        assert.isTrue(hasCycle(externalWorkflow));
+    });
+
     it('should return true if a detached workflow has a cycle', () => {
         const workflow = {
             nodes: [

--- a/testworkflow.js
+++ b/testworkflow.js
@@ -1,0 +1,8 @@
+// const getNextJobs = require('./lib/getNextJobs');
+// const getWorkflow = require('./lib/getWorkflow');
+// const getSrcForJoin = require('./lib/getSrcForJoin');
+// const REQUIRES_WORKFLOW = require('./test/data/requires-workflow-exttrigger');
+//
+// const wf = getWorkflow(REQUIRES_WORKFLOW);
+// // const nextJob = getNextJobs(wf, {trigger:'~sd1234:foo'}))
+// console.log(getSrcForJoin(wf, {jobName: 'sd@4321:bar'}));

--- a/testworkflow.js
+++ b/testworkflow.js
@@ -1,8 +1,0 @@
-// const getNextJobs = require('./lib/getNextJobs');
-// const getWorkflow = require('./lib/getWorkflow');
-// const getSrcForJoin = require('./lib/getSrcForJoin');
-// const REQUIRES_WORKFLOW = require('./test/data/requires-workflow-exttrigger');
-//
-// const wf = getWorkflow(REQUIRES_WORKFLOW);
-// // const nextJob = getNextJobs(wf, {trigger:'~sd1234:foo'}))
-// console.log(getSrcForJoin(wf, {jobName: 'sd@4321:bar'}));


### PR DESCRIPTION
Related: https://github.com/screwdriver-cd/screwdriver/issues/1710
Blocked by: https://github.com/screwdriver-cd/config-parser/pull/94

Previously, we only include nodes & edges from the workflow graph. This PR will generate external nodes & external edges that are downstream for each job.