### PR TITLE
fix(1417): Make node name filter more specific

### DIFF
--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -7,7 +7,7 @@
  * @return {String}            A filtered node name, e.g. foo, foo, ~pr, ~commit, ~release, ~tag, ~sd@1234:foo
  */
 const filterNodeName = name =>
-    (/^~(pr|commit|release|tag|sd@)/.test(name) ? name : name.replace('~', ''));
+    (/^~((pr|commit|release|tag)(?:$|:)|(sd@))/.test(name) ? name : name.replace('~', ''));
 
 /**
  * Get the list of nodes for the graph

--- a/test/data/expected-output.json
+++ b/test/data/expected-output.json
@@ -5,6 +5,7 @@
         { "name": "main" },
         { "name": "foo" },
         { "name": "bar" },
+        { "name": "promote" },
         { "name": "baz" },
         { "name": "~release" },
         { "name": "~tag" }
@@ -14,6 +15,7 @@
         { "src": "~commit", "dest": "main" },
         { "src": "main", "dest": "foo" },
         { "src": "foo", "dest": "bar" },
+        { "src": "promote", "dest": "bar" },
         { "src": "~release", "dest": "baz" },
         { "src": "~tag", "dest": "baz" }
     ]

--- a/test/data/requires-workflow.json
+++ b/test/data/requires-workflow.json
@@ -2,7 +2,8 @@
     "jobs": {
         "main": { "requires": ["~pr", "~commit"] },
         "foo": { "requires": ["main"] },
-        "bar": { "requires": ["foo"] },
+        "bar": { "requires": ["~foo", "~promote"] },
+        "promote": { "requires": [] },
         "baz": { "requires": ["~release", "~tag"] }
     }
 }


### PR DESCRIPTION
## Context

Screwdriver currently handles "requires" job names that start with `~pr`, `~commit`, etc. as if they are special root nodes. 

## Objective

This PR changes the regex in the node name filter to make it match more specifically for `~pr:*` or `~pr` exactly.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1417

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
