### PR TITLE
fix(1710): Do not store ~ for external pipeline dest [1]

### DIFF
--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -68,7 +68,7 @@ const calculateNodes = async (jobs, triggerFactory, pipelineId) => {
         const externalDownstreamAnd = await triggerFactory.getDestFromSrc(srcName);
 
         externalDownstreamOr.forEach((dest) => {
-            nodes.add(dest);
+            nodes.add(dest.replace('~sd@', 'sd@'));
         });
 
         await buildExternalNodes(
@@ -173,7 +173,7 @@ const calculateEdges = async (jobs, triggerFactory, pipelineId) => {
         const externalDownstreamAnd = await triggerFactory.getDestFromSrc(srcName);
 
         externalDownstreamOr.forEach((dest) => {
-            edges.push({ src: jobName, dest });
+            edges.push({ src: jobName, dest: dest.replace('~sd@', 'sd@') });
         });
 
         // Handle join case

--- a/test/data/expected-external-complex.json
+++ b/test/data/expected-external-complex.json
@@ -9,7 +9,7 @@
         { "name": "sd@444:external-level2" },
         { "name": "sd@555:external-level2" },
         { "name": "~sd@888:external-level2" },
-        { "name": "~sd@777:external-level1" },
+        { "name": "sd@777:external-level1" },
         { "name": "sd@111:external-level1" },
         { "name": "sd@333:external-level1" },
         { "name": "sd@666:external-level3" }
@@ -21,7 +21,7 @@
         { "src": "sd@222:external-level2", "dest": "C", "join": true },
         { "src": "sd@444:external-level2", "dest": "C", "join": true },
         { "src": "sd@555:external-level2", "dest": "C", "join": true },
-        { "src": "A", "dest": "~sd@777:external-level1" },
+        { "src": "A", "dest": "sd@777:external-level1" },
         { "src": "A", "dest": "sd@111:external-level1" },
         { "src": "A", "dest": "sd@333:external-level1" },
         { "src": "sd@111:external-level1", "dest": "sd@222:external-level2" },

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -124,7 +124,7 @@ describe('getNextJobs', () => {
              \ ~sd@777:external-level1 -> ~sd@888:external-level2   /
         */
         assert.deepEqual(getNextJobs(EXTERNAL_COMPLEX_WORKFLOW, { trigger: 'A' }),
-            ['B', '~sd@777:external-level1', 'sd@111:external-level1', 'sd@333:external-level1']);
+            ['B', 'sd@777:external-level1', 'sd@111:external-level1', 'sd@333:external-level1']);
         assert.deepEqual(getNextJobs(EXTERNAL_COMPLEX_WORKFLOW,
             { trigger: 'B' }), ['C']);
     });


### PR DESCRIPTION
## Context

Need to make sure we don't store ~ for external pipeline in workflow as a dest.

## Objective

This PR does not store ~ for dest.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1710

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
