### PR TITLE
fix(1973): don't return remote job for pr event

### DIFF
--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { PR_JOB_NAME } = require('screwdriver-data-schema').config.regex;
+const { PR_JOB_NAME, EXTERNAL_TRIGGER_ALL } = require('screwdriver-data-schema').config.regex;
 
 /**
  * Calculate the next jobs to execute, given a workflow and a trigger job
@@ -56,7 +56,8 @@ const getNextJobs = (workflowGraph, config) => {
             }
         // chainPRTrigger[1] must be 'PR-$num' if matches regexp
         } else if (config.chainPR
-                && chainPRTrigger && config.trigger === `${chainPRTrigger[1]}:${edge.src}`) {
+                && chainPRTrigger && config.trigger === `${chainPRTrigger[1]}:${edge.src}`
+                && !EXTERNAL_TRIGGER_ALL.test(edge.dest)) {
             jobs.add(`${chainPRTrigger[1]}:${edge.dest}`);
         }
     });

--- a/test/data/external-join.json
+++ b/test/data/external-join.json
@@ -1,0 +1,20 @@
+{
+    "nodes": [
+        { "name": "~pr" },
+        { "name": "~commit" },
+        { "name": "main" },
+        { "name": "foo" },
+        { "name": "bar" },
+        { "name": "sd@111:baz" },
+        { "name": "sd@1234:foo" }
+    ],
+    "edges": [
+        { "src": "~pr", "dest": "main" },
+        { "src": "~commit", "dest": "main" },
+        { "src": "main", "dest": "foo" },
+        { "src": "foo", "dest": "sd@111:baz" },
+        { "src": "foo", "dest": "sd@1234:foo" },
+        { "src": "sd@1234:foo", "dest": "bar", "join": true },
+        { "src": "sd@111:baz", "dest": "bar", "join": true }
+    ]
+}

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -5,6 +5,7 @@ const getNextJobs = require('../../lib/getNextJobs');
 const WORKFLOW = require('../data/expected-output');
 const EXTERNAL_WORKFLOW = require('../data/expected-external');
 const EXTERNAL_COMPLEX_WORKFLOW = require('../data/expected-external-complex');
+const EXTERNAL_JOIN_WORKFLOW = require('../data/external-join');
 
 describe('getNextJobs', () => {
     it('should throw if trigger not provided', () => {
@@ -127,5 +128,14 @@ describe('getNextJobs', () => {
             ['B', 'sd@777:external-level1', 'sd@111:external-level1', 'sd@333:external-level1']);
         assert.deepEqual(getNextJobs(EXTERNAL_COMPLEX_WORKFLOW,
             { trigger: 'B' }), ['C']);
+    });
+
+    it.only('should not return external job on pr trigger', () => {
+        assert.deepEqual(getNextJobs(EXTERNAL_JOIN_WORKFLOW,
+            { trigger: '~pr', prNum: '1', chainPR: true }), ['PR-1:main']);
+        assert.deepEqual(getNextJobs(EXTERNAL_JOIN_WORKFLOW,
+            { trigger: 'PR-1:main', prNum: '1', chainPR: true }), ['PR-1:foo']);
+        assert.deepEqual(getNextJobs(EXTERNAL_JOIN_WORKFLOW,
+            { trigger: 'PR-1:foo', prNum: '1', chainPR: true }), []);
     });
 });

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -130,7 +130,7 @@ describe('getNextJobs', () => {
             { trigger: 'B' }), ['C']);
     });
 
-    it.only('should not return external job on pr trigger', () => {
+    it('should not return external job on pr trigger', () => {
         assert.deepEqual(getNextJobs(EXTERNAL_JOIN_WORKFLOW,
             { trigger: '~pr', prNum: '1', chainPR: true }), ['PR-1:main']);
         assert.deepEqual(getNextJobs(EXTERNAL_JOIN_WORKFLOW,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
currently workflow-parser returns remote job for pr event when both external join and chainPR are turned on, which breaks pr event

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
do not return remote job for pr event

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1973

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
