### PR TITLE
fix(1968): remove ~ for downstream external job

### DIFF
--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -19,7 +19,7 @@ const filterNodeName = name =>
  */
 const buildExternalNodes = async (children, nodes, triggerFactory) => {
     await Promise.all(children.map(async (dest) => {
-        nodes.add(dest);
+        nodes.add(dest.replace('~sd@', 'sd@'));
 
         const newChildren = await triggerFactory.getDestFromSrc(dest);
 
@@ -89,7 +89,7 @@ const calculateNodes = async (jobs, triggerFactory, pipelineId) => {
  */
 const buildExternalEdges = async (root, children, edges, triggerFactory) => {
     await Promise.all(children.map(async (dest) => {
-        edges.push({ src: root, dest });
+        edges.push({ src: root, dest: dest.replace('~sd@', 'sd@') });
 
         const newChildren = await triggerFactory.getDestFromSrc(dest);
 

--- a/test/data/expected-external-join.json
+++ b/test/data/expected-external-join.json
@@ -12,9 +12,9 @@
         { "src": "~pr", "dest": "main" },
         { "src": "~commit", "dest": "main" },
         { "src": "main", "dest": "foo" },
-        { "src": "foo", "dest": "sd@111:baz" },
-        { "src": "foo", "dest": "sd@1234:foo" },
+        { "src": "sd@111:baz", "dest": "bar", "join": true },
         { "src": "sd@1234:foo", "dest": "bar", "join": true },
-        { "src": "sd@111:baz", "dest": "bar", "join": true }
+        { "src": "foo", "dest": "sd@111:baz" },
+        { "src": "foo", "dest": "sd@1234:foo" }
     ]
 }

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -5,7 +5,7 @@ const getNextJobs = require('../../lib/getNextJobs');
 const WORKFLOW = require('../data/expected-output');
 const EXTERNAL_WORKFLOW = require('../data/expected-external');
 const EXTERNAL_COMPLEX_WORKFLOW = require('../data/expected-external-complex');
-const EXTERNAL_JOIN_WORKFLOW = require('../data/external-join');
+const EXTERNAL_JOIN_WORKFLOW = require('../data/expected-external-join');
 
 describe('getNextJobs', () => {
     it('should throw if trigger not provided', () => {

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -10,6 +10,7 @@ const EXPECTED_OUTPUT = require('../data/expected-output');
 const NO_EDGES = Object.assign({}, EXPECTED_OUTPUT);
 const EXPECTED_EXTERNAL = require('../data/expected-external');
 const EXPECTED_EXTERNAL_COMPLEX = require('../data/expected-external-complex');
+const EXPECTED_EXTERNAL_JOIN = require('../data/expected-external-join');
 
 NO_EDGES.edges = [];
 
@@ -168,6 +169,22 @@ describe('getWorkflow', () => {
                 { src: 'baz', dest: 'bax', join: true }
             ]
         });
+    });
+
+    it('should remove ~ for downstream external trigger', async () => {
+        triggerFactoryMock.getDestFromSrc.withArgs('sd@123:foo').resolves([
+            'sd@111:baz',
+            'sd@1234:foo'
+        ]);
+        const result = await getWorkflow({
+            jobs: {
+                main: { requires: ['~pr', '~commit'] },
+                foo: { requires: ['main'] },
+                bar: { requires: ['sd@111:baz', 'sd@1234:foo'] }
+            }
+        }, triggerFactoryMock, 123);
+
+        assert.deepEqual(result, EXPECTED_EXTERNAL_JOIN);
     });
 
     it('should handle external upstream & downstream join', async () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
currently workflow can have duplicate remote jobs, one with ~ and one without

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
duplicate remote job should not exist

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1968
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
