### PR TITLE
feat(1958): hapi v19 upgrade, node:12. BREAKING CHANGE: data-schema v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-workflow-parser",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Parses and converts pipeline configuration into a workflow",
   "main": "index.js",
   "scripts": {
@@ -42,7 +42,7 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "screwdriver-data-schema": "^19.0.0"
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
+    "screwdriver-data-schema": "^20.0.0"
   },
   "release": {
     "debug": false,

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR upgrades to node:12

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
