### PR TITLE
fix: Remove noop for semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,6 @@
     "screwdriver-data-schema": "^21.0.0"
   },
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   }
 }


### PR DESCRIPTION
## Context
Seeing `Error: Cannot find module './node_modules/semantic-release/src/lib/plugin-noop.js'`]
https://cd.screwdriver.cd/pipelines/529/builds/764489/steps/publish
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
This PR removes old package.json section for noop plugin.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
Related to https://github.com/screwdriver-cd/executor-base/pull/76
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
