### PR TITLE
feat(2767): Get stage workflowGraph [2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ npm install screwdriver-workflow-parser
 ```
 
 ```
-const { getWorkflow, getNextJobs, hasCycle } = require('screwdriver-workflow-parser');
+const { getWorkflow, getNextJobs, getSrcForJoin, hasCycle, hasJoin } = require('screwdriver-workflow-parser');
 
 // Calculate the directed graph workflow from a pipeline config (and parse legacy workflows)
-const workflowGraph = getWorkflow(pipelineConfig, { useLegacy: true });
+const workflowGraph = getWorkflow({ pipelineConfig, triggerFactory });
 
 /* 
 { 
@@ -28,9 +28,17 @@ const commitJobsToTrigger = getNextJobs(workflowGraph, { trigger: '~commit' });
 // Get a list of job names to start as a result of a pull-request event, e.g. [ 'PR-123:a' ]
 const prJobsToTrigger = getNextJobs(workflowGraph, { trigger: '~pr', prNum: 123 });
 
+// Return the join src jobs given a workflowGraph and dest job
+const srcArray = getSrcForJoin(workflowGraph, { jobName: 'foo' });
+
 // Check to see if a given workflow graph has a loop in it. A -> B -> A
 if (hasCycle(workflowGraph)) {
     console.error('Graph contains a loop.');
+}
+
+// Check if the workflow has a join, e.g. A + B -> C
+if (hasJoin(workflowGraph)) {
+    console.log('Graph contains join');
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install screwdriver-workflow-parser
 ```
 
 ```
-const { getWorkflow, getNextJobs, getSrcForJoin, hasCycle, hasJoin } = require('screwdriver-workflow-parser');
+const { getWorkflow, getNextJobs, getSrcForJoin, getFlattenedWorkflow, hasCycle, hasJoin } = require('screwdriver-workflow-parser');
 
 // Calculate the directed graph workflow from a pipeline config (and parse legacy workflows)
 const workflowGraph = getWorkflow({ pipelineConfig, triggerFactory });
@@ -30,6 +30,26 @@ const prJobsToTrigger = getNextJobs(workflowGraph, { trigger: '~pr', prNum: 123 
 
 // Return the join src jobs given a workflowGraph and dest job
 const srcArray = getSrcForJoin(workflowGraph, { jobName: 'foo' });
+
+// Return the flattened workflowGraph given a workflowGraph and stage workflowGraphs
+const flattenedWorkflow = getFlattenedWorkflow(workflowGraph, {
+    deploy: {
+        nodes: [
+            { name: 'C' },
+            { name: 'stage@deploy:setup' },
+            { name: 'D' },
+            { name: 'stage@deploy:teardown' }
+        ],
+        edges: [
+            { src: 'stage@deploy:setup', dest: 'C' },
+            { src: 'C', dest: 'D' }
+        ]
+    },
+    test: {
+        nodes: [{ name: 'E' }, { name: 'stage@test:setup' }, { name: 'stage@test:teardown' }],
+        edges: [{ src: 'stage@test:setup', dest: 'E' }]
+    }
+});
 
 // Check to see if a given workflow graph has a loop in it. A -> B -> A
 if (hasCycle(workflowGraph)) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@
 const getWorkflow = require('./lib/getWorkflow');
 const getNextJobs = require('./lib/getNextJobs');
 const getSrcForJoin = require('./lib/getSrcForJoin');
+const getFlattenedWorkflow = require('./lib/getFlattenedWorkflow');
 const hasCycle = require('./lib/hasCycle');
 const hasJoin = require('./lib/hasJoin');
 
-module.exports = { getWorkflow, getNextJobs, getSrcForJoin, hasCycle, hasJoin };
+module.exports = { getWorkflow, getNextJobs, getSrcForJoin, getFlattenedWorkflow, hasCycle, hasJoin };

--- a/lib/getFlattenedWorkflow.js
+++ b/lib/getFlattenedWorkflow.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const STAGE_PREFIX = /^(?:~)?(stage@)/;
+/**
+ * Flatten workflowGraphs (event and stage)
+ * @method flattenWorkflow
+ * @param  {Object}  workflowGraph  Graph representation of workflow
+ * @return {Boolean}                True if a cycle exists anywhere in the workflow
+ */
+const getFlattenedWorkflow = (workflowGraph, stageWorkflows) => {
+    const flattenedWorkflow = { edges: [], nodes: [] };
+
+    console.log('----workflowGraph: ', workflowGraph);
+    console.log('----stageWorkflows: ', stageWorkflows);
+
+    // Traverse edges, if src is stage, insert teardown prefix
+    // if dest is stage, insert setup prefix
+    workflowGraph.edges.forEach(edge => {
+        let { src, dest } = edge;
+
+        if (STAGE_PREFIX.test(edge.src)) {
+            src = `${edge.src}:teardown`;
+        }
+        if (STAGE_PREFIX.test(edge.dest)) {
+            dest = `${edge.dest}:setup`;
+        }
+
+        const newEdge = { src, dest };
+
+        if (edge.join) {
+            newEdge.join = edge.join;
+        }
+
+        flattenedWorkflow.edges.push(newEdge);
+    });
+    // Remove stage nodes
+    flattenedWorkflow.nodes = workflowGraph.nodes.filter(node => !STAGE_PREFIX.test(node.name));
+
+    // Concat all edges, nodes
+    Object.values(stageWorkflows).forEach(stage => {
+        console.log('----stage: ', stage);
+
+        flattenedWorkflow.edges = flattenedWorkflow.edges.concat(stage.edges);
+        flattenedWorkflow.nodes = flattenedWorkflow.nodes.concat(stage.nodes);
+    });
+
+    return flattenedWorkflow;
+};
+
+module.exports = getFlattenedWorkflow;

--- a/lib/getFlattenedWorkflow.js
+++ b/lib/getFlattenedWorkflow.js
@@ -10,9 +10,6 @@ const STAGE_PREFIX = /^(?:~)?(stage@)/;
 const getFlattenedWorkflow = (workflowGraph, stageWorkflows) => {
     const flattenedWorkflow = { edges: [], nodes: [] };
 
-    console.log('----workflowGraph: ', workflowGraph);
-    console.log('----stageWorkflows: ', stageWorkflows);
-
     // Traverse edges, if src is stage, insert teardown prefix
     // if dest is stage, insert setup prefix
     workflowGraph.edges.forEach(edge => {
@@ -38,8 +35,6 @@ const getFlattenedWorkflow = (workflowGraph, stageWorkflows) => {
 
     // Concat all edges, nodes
     Object.values(stageWorkflows).forEach(stage => {
-        console.log('----stage: ', stage);
-
         flattenedWorkflow.edges = flattenedWorkflow.edges.concat(stage.edges);
         flattenedWorkflow.nodes = flattenedWorkflow.nodes.concat(stage.nodes);
     });

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -8,7 +8,8 @@ const hoek = require('@hapi/hoek');
  * @param  {String}       name A Node Name, e.g. foo, ~foo, ~pr, ~commit, ~release, ~tag, ~sd@1234:foo
  * @return {String}            A filtered node name, e.g. foo, foo, ~pr, ~commit, ~release, ~tag, ~sd@1234:foo
  */
-const filterNodeName = name => (/^~((pr|commit|release|tag)(?:$|:)|(sd@))/.test(name) ? name : name.replace('~', ''));
+const filterNodeName = name =>
+    /^~((pr|commit|release|tag|stage@)(?:$|:)|(sd@))/.test(name) ? name : name.replace('~', '');
 
 /**
  * Build external nodes for its downstream jobs, DFS to traverse its children
@@ -28,6 +29,24 @@ const buildExternalNodes = async (children, nodes, triggerFactory) => {
             await buildExternalNodes(newChildren, nodes, triggerFactory);
         })
     );
+};
+
+/**
+ * Add display name to node
+ * @param  {Array}  jobs                  Array of jobs
+ * @param  {String} jobName               Job name
+ * @param  {Object} node                  Node object
+ */
+const handleDisplayName = (jobs, jobName, node) => {
+    // Add display name
+    const displayName = hoek.reach(jobs[jobName], 'annotations>screwdriver.cd/displayName', {
+        separator: '>',
+        default: undefined
+    });
+
+    if (displayName !== undefined) {
+        node.displayName = displayName;
+    }
 };
 
 /**
@@ -54,14 +73,48 @@ const calculateNodes = async (jobs, triggerFactory, externalDownstreamOrs, exter
         return [...nodes].map(name => ({ name }));
     }
 
+    let stagesDict = [];
+
     // new implementation. allow external join
     await Promise.all(
         Object.keys(jobs).map(async jobName => {
-            nodes.add(jobName);
+            const stageObj = jobs[jobName].stage;
+            const stageNode = { name: jobName };
+
+            // Add display name
+            handleDisplayName(jobs, jobName, stageNode);
+
+            // Stage node
+            if (stageObj) {
+                if (stagesDict[stageObj.name]) {
+                    stagesDict[stageObj.name].push(stageNode);
+                } else {
+                    const newStageObj = { [stageObj.name]: [stageNode] };
+
+                    stagesDict = { ...stagesDict, ...newStageObj };
+                }
+            } else {
+                nodes.add(jobName);
+            }
 
             // upstream nodes
             if (Array.isArray(jobs[jobName].requires)) {
-                jobs[jobName].requires.forEach(n => nodes.add(filterNodeName(n)));
+                jobs[jobName].requires.forEach(n => {
+                    // Stage node
+                    if (/^(?:~)?(stage@)/.test(n)) {
+                        const [, stageName] = n.match(/^(?:~)?stage@([\w-]+)(?::([\w-]+))?$/);
+
+                        if (stageName && stagesDict[stageName]) {
+                            stagesDict[stageName].push({ name: filterNodeName(n) });
+                        } else {
+                            const newStageObj = { [stageName]: [{ name: filterNodeName(n) }] };
+
+                            stagesDict = { ...stagesDict, ...newStageObj };
+                        }
+                    } else if (!jobs[filterNodeName(n)] || !jobs[filterNodeName(n)].stage) {
+                        nodes.add(filterNodeName(n));
+                    }
+                });
             }
 
             // downstream nodes
@@ -76,19 +129,21 @@ const calculateNodes = async (jobs, triggerFactory, externalDownstreamOrs, exter
         })
     );
 
-    return [...nodes].map(name => {
-        const m = { name };
-        const displayName = hoek.reach(jobs[name], 'annotations>screwdriver.cd/displayName', {
-            separator: '>',
-            default: undefined
-        });
+    // Create stage nodes
+    Object.keys(stagesDict).forEach(stage => {
+        nodes.add(`~stage@${stage}`);
+    });
 
-        if (displayName !== undefined) {
-            m.displayName = displayName;
-        }
+    const nodeObjects = [...nodes].map(name => {
+        const m = { name };
+
+        // Add display name
+        handleDisplayName(jobs, name, m);
 
         return m;
     });
+
+    return { nodes: nodeObjects, stageNodes: stagesDict };
 };
 
 /**
@@ -121,8 +176,9 @@ const buildExternalEdges = async (root, children, edges, triggerFactory) => {
  * @param  {Object}         externalDownstreamAnds Hash of externalDownstreamAnd. ex {jobName: externalDownstreamAnd}
  * @return {Array}          List of graph edges { src, dest }
  */
-const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, externalDownstreamAnds) => {
+const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, externalDownstreamAnds, stageConfig) => {
     const edges = [];
+    let stagesDict = [];
 
     // for backward compatibility. TODO: remove this block later
     if (!triggerFactory) {
@@ -158,6 +214,7 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
     await Promise.all(
         Object.keys(jobs).map(async jobName => {
             const job = jobs[jobName];
+            const stageObj = job.stage;
 
             if (Array.isArray(job.requires)) {
                 // Calculate which upstream jobs trigger the current job
@@ -166,7 +223,27 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
                 const isJoin = upstreamAnd.size > 1;
 
                 upstreamOr.forEach(src => {
-                    edges.push({ src: filterNodeName(src), dest: jobName });
+                    const [source] = src.split(':');
+
+                    // Skip adding edge when src is stage setup
+                    if (stageObj) {
+                        if (!stageObj.startFrom) {
+                            const stageEdge = { src: filterNodeName(source), dest: jobName };
+
+                            if (stagesDict[stageObj.name]) {
+                                stagesDict[stageObj.name].push(stageEdge);
+                            } else {
+                                const newStageObj = { [stageObj.name]: [stageEdge] };
+
+                                stagesDict = { ...stagesDict, ...newStageObj };
+                            }
+                        }
+                    } else {
+                        edges.push({
+                            src: src.startsWith('~stage@') ? filterNodeName(source) : filterNodeName(src),
+                            dest: jobName
+                        });
+                    }
                 });
                 upstreamAnd.forEach(src => {
                     const obj = { src, dest: jobName };
@@ -174,7 +251,23 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
                     if (isJoin) {
                         obj.join = true;
                     }
-                    edges.push(obj);
+
+                    // Skip adding edge when src is stage setup
+                    if (stageObj) {
+                        if (!stageObj.startFrom) {
+                            const stageEdge = obj;
+
+                            if (stagesDict[stageObj.name]) {
+                                stagesDict[stageObj.name].push(stageEdge);
+                            } else {
+                                const newStageObj = { [stageObj.name]: [stageEdge] };
+
+                                stagesDict = { ...stagesDict, ...newStageObj };
+                            }
+                        }
+                    } else {
+                        edges.push(obj);
+                    }
                 });
             }
 
@@ -190,7 +283,20 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
         })
     );
 
-    return edges;
+    // Handle stage requires
+    if (stageConfig) {
+        Object.keys(stageConfig).forEach(stage => {
+            if (Array.isArray(stageConfig[stage].requires)) {
+                stageConfig[stage].requires.forEach(upstream => {
+                    edges.push({ src: upstream, dest: `stage@${stage}` });
+                });
+            } else if (stageConfig[stage].requires) {
+                edges.push({ src: stageConfig[stage].requires, dest: `stage@${stage}` });
+            }
+        });
+    }
+
+    return { edges, stageEdges: stagesDict };
 };
 
 /**
@@ -202,8 +308,8 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
  * @param  {Number}         pipelineId              Id of the current pipeline
  * @return {Object}         List of nodes and edges {nodes, edges}
  */
-const getWorkflow = async (pipelineConfig, triggerFactory, pipelineId) => {
-    const jobConfig = pipelineConfig.jobs;
+const getWorkflow = async ({ pipelineConfig, triggerFactory, pipelineId, pipelineOnly = true }) => {
+    const { jobs: jobConfig, stages: stageConfig } = pipelineConfig;
     const externalDownstreamOrs = {};
     const externalDownstreamAnds = {};
 
@@ -225,10 +331,38 @@ const getWorkflow = async (pipelineConfig, triggerFactory, pipelineId) => {
         );
     }
 
-    const nodes = await calculateNodes(jobConfig, triggerFactory, externalDownstreamOrs, externalDownstreamAnds);
-    const edges = await calculateEdges(jobConfig, triggerFactory, externalDownstreamOrs, externalDownstreamAnds);
+    const { nodes: newNodes, stageNodes } = await calculateNodes(
+        jobConfig,
+        triggerFactory,
+        externalDownstreamOrs,
+        externalDownstreamAnds
+    );
+    const { edges: newEdges, stageEdges } = await calculateEdges(
+        jobConfig,
+        triggerFactory,
+        externalDownstreamOrs,
+        externalDownstreamAnds,
+        stageConfig
+    );
 
-    return { nodes, edges };
+    // Handle stage triggers
+    // Remove stage-specific jobs from main workflowGraph(nodes and edges)
+    const stageWorkflows = {};
+
+    if (!pipelineOnly && stageConfig) {
+        // Split all stage nodes
+        const stageNames = Object.keys(stageConfig);
+
+        stageNames.forEach(stageName => {
+            stageWorkflows[stageName] = { nodes: stageNodes[stageName], edges: stageEdges[stageName] };
+        });
+    }
+
+    if (pipelineOnly) {
+        return { nodes: newNodes, edges: newEdges };
+    }
+
+    return { workflow: { nodes: newNodes, edges: newEdges }, stageWorkflows };
 };
 
 module.exports = getWorkflow;

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -254,12 +254,8 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
 
             if (Array.isArray(job.requires)) {
                 // Calculate which upstream jobs trigger the current job
-                const upstreamOr = new Set(
-                    job.requires.filter(name => name.charAt(0) === '~' || name.startsWith(STAGE_PREFIX))
-                );
-                const upstreamAnd = new Set(
-                    job.requires.filter(name => name.charAt(0) !== '~' && !name.startsWith(STAGE_PREFIX))
-                );
+                const upstreamOr = new Set(job.requires.filter(name => name.charAt(0) === '~'));
+                const upstreamAnd = new Set(job.requires.filter(name => name.charAt(0) !== '~'));
                 const isJoin = upstreamAnd.size > 1;
 
                 upstreamOr.forEach(src => {
@@ -335,7 +331,8 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
  * @param  {Number}         pipelineId              Id of the current pipeline
  * @return {Object}         List of nodes and edges {nodes, edges}
  */
-const getWorkflow = async ({ pipelineConfig, triggerFactory, pipelineId, pipelineOnly = true }) => {
+const getWorkflow = async ({ pipelineConfig, triggerFactory, pipelineId }) => {
+    const pipelineOnly = typeof pipelineConfig.stages === 'undefined';
     const { jobs: jobConfig, stages: stageConfig } = pipelineConfig;
     const externalDownstreamOrs = {};
     const externalDownstreamAnds = {};
@@ -373,7 +370,7 @@ const getWorkflow = async ({ pipelineConfig, triggerFactory, pipelineId, pipelin
     );
 
     if (pipelineOnly) {
-        return { nodes: newNodes, edges: newEdges };
+        return { pipelineWorkflow: { nodes: newNodes, edges: newEdges } };
     }
 
     // Handle stage triggers
@@ -389,7 +386,7 @@ const getWorkflow = async ({ pipelineConfig, triggerFactory, pipelineId, pipelin
         });
     }
 
-    return { workflow: { nodes: newNodes, edges: newEdges }, stageWorkflows };
+    return { pipelineWorkflow: { nodes: newNodes, edges: newEdges }, stageWorkflows };
 };
 
 module.exports = getWorkflow;

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const clone = require('clone');
 const hoek = require('@hapi/hoek');
 const STAGE_PREFIX = 'stage@';
 
@@ -51,6 +52,48 @@ const handleDisplayName = (jobs, jobName, node) => {
 };
 
 /**
+ * Check if there is already an entry in the stage dict for that stage name
+ * If it exists, update it; otherwise, create it
+ * @param  {Object} stagesDict                    Stage dict
+ * @param  {String} stageName                     Stage name
+ * @param  {Object} stageEdgeOrNode               Stage edge or stage node
+ * @return {Object}                               Updated stage dict
+ */
+const updateStageDict = (stagesDict, stageName, stageEdgeOrNode) => {
+    let tempDict = clone(stagesDict);
+
+    if (tempDict[stageName]) {
+        tempDict[stageName].push(stageEdgeOrNode);
+    } else {
+        const newStageObj = { [stageName]: [stageEdgeOrNode] };
+
+        tempDict = { ...tempDict, ...newStageObj };
+    }
+
+    return tempDict;
+};
+
+/**
+ * Check if setup or teardown stage node already exists
+ * Add if it does not exist
+ * @param {Object} stagesDict  Stages dict
+ * @param {String} stageName   Stage name
+ * @param {String} type        Type of stage node ('setup' or 'teardown')
+ */
+const addSetupTeardownNode = (stagesDict, stageName, type) => {
+    let tempDict = clone(stagesDict);
+    const stageNodeName = `${STAGE_PREFIX}${stageName}:${type}`;
+    const stageNode = tempDict[stageName].find(node => node.name === stageNodeName);
+
+    // Add stage setup or teardown job
+    if (!stageNode) {
+        tempDict = updateStageDict(tempDict, stageName, { name: stageNodeName });
+    }
+
+    return tempDict;
+};
+
+/**
  * Get the list of nodes for the graph
  * @method calculateNodes
  * @param  {Object}          jobs                   Hash of job configs
@@ -87,13 +130,7 @@ const calculateNodes = async (jobs, triggerFactory, externalDownstreamOrs, exter
 
             // Stage node
             if (stageObj) {
-                if (stagesDict[stageObj.name]) {
-                    stagesDict[stageObj.name].push(stageNode);
-                } else {
-                    const newStageObj = { [stageObj.name]: [stageNode] };
-
-                    stagesDict = { ...stagesDict, ...newStageObj };
-                }
+                stagesDict = updateStageDict(stagesDict, stageObj.name, stageNode);
             } else {
                 nodes.add(jobName);
             }
@@ -105,13 +142,7 @@ const calculateNodes = async (jobs, triggerFactory, externalDownstreamOrs, exter
                     if (/^(?:~)?(stage@)/.test(n)) {
                         const [, stageName] = n.match(/^(?:~)?stage@([\w-]+)(?::([\w-]+))?$/);
 
-                        if (stageName && stagesDict[stageName]) {
-                            stagesDict[stageName].push({ name: filterNodeName(n) });
-                        } else {
-                            const newStageObj = { [stageName]: [{ name: filterNodeName(n) }] };
-
-                            stagesDict = { ...stagesDict, ...newStageObj };
-                        }
+                        stagesDict = updateStageDict(stagesDict, stageName, { name: filterNodeName(n) });
                     } else if (!jobs[filterNodeName(n)] || !jobs[filterNodeName(n)].stage) {
                         nodes.add(filterNodeName(n));
                     }
@@ -130,9 +161,13 @@ const calculateNodes = async (jobs, triggerFactory, externalDownstreamOrs, exter
         })
     );
 
-    // Create stage nodes
-    Object.keys(stagesDict).forEach(stage => {
-        nodes.add(`~stage@${stage}`);
+    // Create stage nodes in main workflowGraph
+    Object.keys(stagesDict).forEach(stageName => {
+        nodes.add(`~${STAGE_PREFIX}${stageName}`);
+
+        // Create stage setup/teardown node if they do not exist
+        stagesDict = addSetupTeardownNode(stagesDict, stageName, 'setup');
+        stagesDict = addSetupTeardownNode(stagesDict, stageName, 'teardown');
     });
 
     const nodeObjects = [...nodes].map(name => {
@@ -230,19 +265,14 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
                 upstreamOr.forEach(src => {
                     const [source] = src.split(':');
 
-                    // Skip adding edge when src is stage setup
                     if (stageObj) {
+                        let stageEdge = { src: filterNodeName(src), dest: jobName };
+
+                        // Remove stage prefix when src is not stage setup
                         if (!stageObj.startFrom) {
-                            const stageEdge = { src: filterNodeName(source), dest: jobName };
-
-                            if (stagesDict[stageObj.name]) {
-                                stagesDict[stageObj.name].push(stageEdge);
-                            } else {
-                                const newStageObj = { [stageObj.name]: [stageEdge] };
-
-                                stagesDict = { ...stagesDict, ...newStageObj };
-                            }
+                            stageEdge = { src: filterNodeName(source), dest: jobName };
                         }
+                        stagesDict = updateStageDict(stagesDict, stageObj.name, stageEdge);
                     } else {
                         edges.push({
                             src: src.startsWith(STAGE_PREFIX) ? filterNodeName(source) : filterNodeName(src),
@@ -260,15 +290,7 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
                     // Skip adding edge when src is stage setup
                     if (stageObj) {
                         if (!stageObj.startFrom) {
-                            const stageEdge = obj;
-
-                            if (stagesDict[stageObj.name]) {
-                                stagesDict[stageObj.name].push(stageEdge);
-                            } else {
-                                const newStageObj = { [stageObj.name]: [stageEdge] };
-
-                                stagesDict = { ...stagesDict, ...newStageObj };
-                            }
+                            stagesDict = updateStageDict(stagesDict, stageObj.name, obj);
                         }
                     } else {
                         edges.push(obj);

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -345,21 +345,21 @@ const getWorkflow = async ({ pipelineConfig, triggerFactory, pipelineId, pipelin
         stageConfig
     );
 
+    if (pipelineOnly) {
+        return { nodes: newNodes, edges: newEdges };
+    }
+
     // Handle stage triggers
     // Remove stage-specific jobs from main workflowGraph(nodes and edges)
     const stageWorkflows = {};
 
-    if (!pipelineOnly && stageConfig) {
+    if (stageConfig) {
         // Split all stage nodes
         const stageNames = Object.keys(stageConfig);
 
         stageNames.forEach(stageName => {
             stageWorkflows[stageName] = { nodes: stageNodes[stageName], edges: stageEdges[stageName] };
         });
-    }
-
-    if (pipelineOnly) {
-        return { nodes: newNodes, edges: newEdges };
     }
 
     return { workflow: { nodes: newNodes, edges: newEdges }, stageWorkflows };

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const hoek = require('@hapi/hoek');
+const STAGE_PREFIX = 'stage@';
 
 /**
  * Remove the ~ prefix for logical OR on select node names.
@@ -218,8 +219,12 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
 
             if (Array.isArray(job.requires)) {
                 // Calculate which upstream jobs trigger the current job
-                const upstreamOr = new Set(job.requires.filter(name => name.charAt(0) === '~'));
-                const upstreamAnd = new Set(job.requires.filter(name => name.charAt(0) !== '~'));
+                const upstreamOr = new Set(
+                    job.requires.filter(name => name.charAt(0) === '~' || name.startsWith(STAGE_PREFIX))
+                );
+                const upstreamAnd = new Set(
+                    job.requires.filter(name => name.charAt(0) !== '~' && !name.startsWith(STAGE_PREFIX))
+                );
                 const isJoin = upstreamAnd.size > 1;
 
                 upstreamOr.forEach(src => {
@@ -240,7 +245,7 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
                         }
                     } else {
                         edges.push({
-                            src: src.startsWith('~stage@') ? filterNodeName(source) : filterNodeName(src),
+                            src: src.startsWith(STAGE_PREFIX) ? filterNodeName(source) : filterNodeName(src),
                             dest: jobName
                         });
                     }

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -228,7 +228,7 @@ const removeStageSuffix = src => {
  * @param  {Object}         externalDownstreamAnds Hash of externalDownstreamAnd. ex {jobName: externalDownstreamAnd}
  * @return {Array}          List of graph edges { src, dest }
  */
-const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, externalDownstreamAnds, stageConfig) => {
+const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, externalDownstreamAnds) => {
     const edges = [];
     let stagesDict = [];
 
@@ -286,6 +286,7 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
                         });
                     }
                 });
+
                 upstreamAnd.forEach(src => {
                     const obj = { src, dest: jobName };
 
@@ -299,6 +300,9 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
                             stagesDict = updateStageDict(stagesDict, stageObj.name, obj);
                         }
                     } else {
+                        if (src.endsWith(':teardown')) {
+                            obj.src = removeStageSuffix(src);
+                        }
                         edges.push(obj);
                     }
                 });
@@ -317,17 +321,17 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
     );
 
     // Handle stage requires
-    if (stageConfig) {
-        Object.keys(stageConfig).forEach(stage => {
-            if (Array.isArray(stageConfig[stage].requires)) {
-                stageConfig[stage].requires.forEach(upstream => {
-                    edges.push({ src: removeStageSuffix(upstream), dest: `stage@${stage}` });
-                });
-            } else if (stageConfig[stage].requires) {
-                edges.push({ src: removeStageSuffix(stageConfig[stage].requires), dest: `stage@${stage}` });
-            }
-        });
-    }
+    // if (stageConfig) {
+    //     Object.keys(stageConfig).forEach(stage => {
+    //         if (Array.isArray(stageConfig[stage].requires)) {
+    //             stageConfig[stage].requires.forEach(upstream => {
+    //                 edges.push({ src: removeStageSuffix(upstream), dest: `stage@${stage}` });
+    //             });
+    //         } else if (stageConfig[stage].requires) {
+    //             edges.push({ src: removeStageSuffix(stageConfig[stage].requires), dest: `stage@${stage}` });
+    //         }
+    //     });
+    // }
 
     return { edges, stageEdges: stagesDict };
 };

--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -3,6 +3,7 @@
 const clone = require('clone');
 const hoek = require('@hapi/hoek');
 const STAGE_PREFIX = 'stage@';
+const STAGE_START = ':setup';
 
 /**
  * Remove the ~ prefix for logical OR on select node names.
@@ -63,7 +64,11 @@ const updateStageDict = (stagesDict, stageName, stageEdgeOrNode) => {
     let tempDict = clone(stagesDict);
 
     if (tempDict[stageName]) {
-        tempDict[stageName].push(stageEdgeOrNode);
+        const stageNode = tempDict[stageName].find(node => node.name === stageEdgeOrNode.name);
+
+        if (!stageNode) {
+            tempDict[stageName].push(stageEdgeOrNode);
+        }
     } else {
         const newStageObj = { [stageName]: [stageEdgeOrNode] };
 
@@ -73,25 +78,21 @@ const updateStageDict = (stagesDict, stageName, stageEdgeOrNode) => {
     return tempDict;
 };
 
-/**
- * Check if setup or teardown stage node already exists
- * Add if it does not exist
- * @param {Object} stagesDict  Stages dict
- * @param {String} stageName   Stage name
- * @param {String} type        Type of stage node ('setup' or 'teardown')
- */
-const addSetupTeardownNode = (stagesDict, stageName, type) => {
-    let tempDict = clone(stagesDict);
-    const stageNodeName = `${STAGE_PREFIX}${stageName}:${type}`;
-    const stageNode = tempDict[stageName].find(node => node.name === stageNodeName);
-
-    // Add stage setup or teardown job
-    if (!stageNode) {
-        tempDict = updateStageDict(tempDict, stageName, { name: stageNodeName });
-    }
-
-    return tempDict;
-};
+// /**
+//  * Check if setup or teardown stage node already exists
+//  * Add if it does not exist
+//  * @param {Object} stagesDict  Stages dict
+//  * @param {String} stageName   Stage name
+//  * @param {String} type        Type of stage node ('setup' or 'teardown')
+//  */
+// const addSetupTeardownNode = (stagesDict, stageName, type) => {
+//     let tempDict = clone(stagesDict);
+//     const stageNodeName = `${STAGE_PREFIX}${stageName}:${type}`;
+//
+//     tempDict = updateStageDict(tempDict, stageName, { name: stageNodeName });
+//
+//     return tempDict;
+// };
 
 /**
  * Get the list of nodes for the graph
@@ -165,9 +166,9 @@ const calculateNodes = async (jobs, triggerFactory, externalDownstreamOrs, exter
     Object.keys(stagesDict).forEach(stageName => {
         nodes.add(`~${STAGE_PREFIX}${stageName}`);
 
-        // Create stage setup/teardown node if they do not exist
-        stagesDict = addSetupTeardownNode(stagesDict, stageName, 'setup');
-        stagesDict = addSetupTeardownNode(stagesDict, stageName, 'teardown');
+        // // Create stage setup/teardown node if they do not exist
+        // stagesDict = addSetupTeardownNode(stagesDict, stageName, 'setup');
+        // stagesDict = addSetupTeardownNode(stagesDict, stageName, 'teardown');
     });
 
     const nodeObjects = [...nodes].map(name => {
@@ -201,6 +202,21 @@ const buildExternalEdges = async (root, children, edges, triggerFactory) => {
             await buildExternalEdges(dest, newChildren, edges, triggerFactory);
         })
     );
+};
+
+/**
+ * Remove ':teardown' or ':setup' if it exists for stage name 'stage@deploy:teardown'
+ * @param  {String} src               Source name
+ * @return {String}                   Returns shortened stage name
+ */
+const removeStageSuffix = src => {
+    if (src.startsWith(STAGE_PREFIX)) {
+        const [stageOrExternalPipeline] = src.split(':');
+
+        return stageOrExternalPipeline;
+    }
+
+    return filterNodeName(src);
 };
 
 /**
@@ -259,19 +275,13 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
                 const isJoin = upstreamAnd.size > 1;
 
                 upstreamOr.forEach(src => {
-                    const [source] = src.split(':');
-
                     if (stageObj) {
-                        let stageEdge = { src: filterNodeName(src), dest: jobName };
+                        const stageEdge = { src: removeStageSuffix(src), dest: jobName };
 
-                        // Remove stage prefix when src is not stage setup
-                        if (!stageObj.startFrom) {
-                            stageEdge = { src: filterNodeName(source), dest: jobName };
-                        }
                         stagesDict = updateStageDict(stagesDict, stageObj.name, stageEdge);
                     } else {
                         edges.push({
-                            src: src.startsWith(STAGE_PREFIX) ? filterNodeName(source) : filterNodeName(src),
+                            src: removeStageSuffix(src),
                             dest: jobName
                         });
                     }
@@ -285,7 +295,7 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
 
                     // Skip adding edge when src is stage setup
                     if (stageObj) {
-                        if (!stageObj.startFrom) {
+                        if (!src.endsWith(STAGE_START)) {
                             stagesDict = updateStageDict(stagesDict, stageObj.name, obj);
                         }
                     } else {
@@ -311,10 +321,10 @@ const calculateEdges = async (jobs, triggerFactory, externalDownstreamOrs, exter
         Object.keys(stageConfig).forEach(stage => {
             if (Array.isArray(stageConfig[stage].requires)) {
                 stageConfig[stage].requires.forEach(upstream => {
-                    edges.push({ src: upstream, dest: `stage@${stage}` });
+                    edges.push({ src: removeStageSuffix(upstream), dest: `stage@${stage}` });
                 });
             } else if (stageConfig[stage].requires) {
-                edges.push({ src: stageConfig[stage].requires, dest: `stage@${stage}` });
+                edges.push({ src: removeStageSuffix(stageConfig[stage].requires), dest: `stage@${stage}` });
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@hapi/hoek": "^10.0.1",
+    "clone": "^2.1.2",
     "screwdriver-data-schema": "^22.0.1"
   },
   "release": {

--- a/test/lib/getFlattenedWorkflow.test.js
+++ b/test/lib/getFlattenedWorkflow.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const { assert } = require('chai');
+const getFlattenedWorkflow = require('../../lib/getFlattenedWorkflow');
+
+describe('getFlattenedWorkflow', () => {
+    it('should return flattened workflow with stage info', () => {
+        const workflow = {
+            nodes: [
+                { name: '~pr' },
+                { name: '~commit' },
+                { name: 'foo' },
+                { name: 'A' },
+                { name: 'B' },
+                { name: '~stage@other' },
+                { name: '~stage@deploy' },
+                { name: '~stage@test' }
+            ],
+            edges: [
+                { src: '~commit', dest: 'foo' },
+                { src: 'foo', dest: 'A' },
+                { src: 'stage@other', dest: 'B', join: true },
+                { src: 'foo', dest: 'B', join: true },
+                { src: 'A', dest: 'stage@deploy' },
+                { src: 'foo', dest: 'stage@test' }
+            ]
+        };
+        const stageWorkflows = {
+            other: {
+                nodes: [
+                    { name: 'stage@other:teardown' },
+                    { name: 'main' },
+                    { name: 'stage@other:setup' },
+                    { name: 'publish' }
+                ],
+                edges: [
+                    { src: 'stage@other:setup', dest: 'main' },
+                    { src: 'main', dest: 'publish' }
+                ]
+            },
+            deploy: {
+                nodes: [
+                    { name: 'C' },
+                    { name: 'stage@deploy:setup' },
+                    { name: 'D' },
+                    { name: 'stage@deploy:teardown' }
+                ],
+                edges: [
+                    { src: 'stage@deploy:setup', dest: 'C' },
+                    { src: 'C', dest: 'D' }
+                ]
+            },
+            test: {
+                nodes: [{ name: 'E' }, { name: 'stage@test:setup' }, { name: 'stage@test:teardown' }],
+                edges: [{ src: 'stage@test:setup', dest: 'E' }]
+            }
+        };
+        const expectedFlattenedWorkflow = {
+            edges: [
+                { src: '~commit', dest: 'foo' },
+                { src: 'foo', dest: 'A' },
+                { src: 'stage@other:teardown', dest: 'B', join: true },
+                { src: 'foo', dest: 'B', join: true },
+                { src: 'A', dest: 'stage@deploy:setup' },
+                { src: 'foo', dest: 'stage@test:setup' },
+                { src: 'stage@other:setup', dest: 'main' },
+                { src: 'main', dest: 'publish' },
+                { src: 'stage@deploy:setup', dest: 'C' },
+                { src: 'C', dest: 'D' },
+                { src: 'stage@test:setup', dest: 'E' }
+            ],
+            nodes: [
+                { name: '~pr' },
+                { name: '~commit' },
+                { name: 'foo' },
+                { name: 'A' },
+                { name: 'B' },
+                { name: 'stage@other:teardown' },
+                { name: 'main' },
+                { name: 'stage@other:setup' },
+                { name: 'publish' },
+                { name: 'C' },
+                { name: 'stage@deploy:setup' },
+                { name: 'D' },
+                { name: 'stage@deploy:teardown' },
+                { name: 'E' },
+                { name: 'stage@test:setup' },
+                { name: 'stage@test:teardown' }
+            ]
+        };
+
+        assert.deepEqual(getFlattenedWorkflow(workflow, stageWorkflows), expectedFlattenedWorkflow);
+    });
+
+    it('should return workflow with no stage info', () => {
+        const workflow = {
+            nodes: [{ name: '~pr' }, { name: '~commit' }, { name: 'foo' }, { name: 'A' }, { name: 'B' }],
+            edges: [
+                { src: '~commit', dest: 'foo' },
+                { src: 'foo', dest: 'A' },
+                { src: 'foo', dest: 'B' }
+            ]
+        };
+        const stageWorkflows = {};
+        const expectedFlattenedWorkflow = {
+            edges: [
+                { src: '~commit', dest: 'foo' },
+                { src: 'foo', dest: 'A' },
+                { src: 'foo', dest: 'B' }
+            ],
+            nodes: [{ name: '~pr' }, { name: '~commit' }, { name: 'foo' }, { name: 'A' }, { name: 'B' }]
+        };
+
+        assert.deepEqual(getFlattenedWorkflow(workflow, stageWorkflows), expectedFlattenedWorkflow);
+    });
+});

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -99,11 +99,11 @@ describe('getWorkflow', () => {
                 E: { requires: ['stage@test:setup'], stage: { name: 'test', startFrom: true } },
                 main: { requires: ['stage@other:setup'], stage: { name: 'other', startFrom: true } },
                 publish: { requires: ['main'], stage: { name: 'other' } },
-                'stage@other:setup': { stage: { name: 'other' } },
+                'stage@other:setup': { requires: [], stage: { name: 'other' } },
                 'stage@other:teardown': { stage: { name: 'other' } },
-                'stage@deploy:setup': { stage: { name: 'deploy' } },
+                'stage@deploy:setup': { requires: ['A'], stage: { name: 'deploy' } },
                 'stage@deploy:teardown': { stage: { name: 'deploy' } },
-                'stage@test:setup': { stage: { name: 'test' } },
+                'stage@test:setup': { requires: ['foo'], stage: { name: 'test' } },
                 'stage@test:teardown': { stage: { name: 'test' } }
             },
             stages: {

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -98,7 +98,13 @@ describe('getWorkflow', () => {
                 D: { requires: ['C'], stage: { name: 'deploy' } },
                 E: { requires: ['stage@test:setup'], stage: { name: 'test', startFrom: true } },
                 main: { requires: ['stage@other:setup'], stage: { name: 'other', startFrom: true } },
-                publish: { requires: ['main'], stage: { name: 'other' } }
+                publish: { requires: ['main'], stage: { name: 'other' } },
+                'stage@other:setup': { stage: { name: 'other' } },
+                'stage@other:teardown': { stage: { name: 'other' } },
+                'stage@deploy:setup': { stage: { name: 'deploy' } },
+                'stage@deploy:teardown': { stage: { name: 'deploy' } },
+                'stage@test:setup': { stage: { name: 'test' } },
+                'stage@test:teardown': { stage: { name: 'test' } }
             },
             stages: {
                 other: {

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -87,10 +87,10 @@ describe('getWorkflow', () => {
             jobs: {
                 foo: { requires: ['~commit'] },
                 A: { requires: ['foo'] },
-                B: { requires: ['foo', '~stage@other:teardown'] },
-                C: { requires: ['~stage@deploy:setup'], stage: { name: 'deploy', startFrom: true } },
+                B: { requires: ['foo', 'stage@other:teardown'] },
+                C: { requires: ['stage@deploy:setup'], stage: { name: 'deploy', startFrom: true } },
                 D: { requires: ['~C'], stage: { name: 'deploy' } },
-                main: { requires: ['~stage@other:setup'], stage: { name: 'other', startFrom: true } },
+                main: { requires: ['stage@other:setup'], stage: { name: 'other', startFrom: true } },
                 publish: { requires: ['main'], stage: { name: 'other' } }
             },
             stages: {

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -30,12 +30,18 @@ describe('getWorkflow', () => {
     });
 
     it('should convert a config with job-requires workflow to directed graph', async () => {
-        const requires = await getWorkflow({ pipelineConfig: REQUIRES_WORKFLOW, triggerFactory: triggerFactoryMock });
-        const legacyRequires = await getWorkflow({
+        const { pipelineWorkflow: requires } = await getWorkflow({
+            pipelineConfig: REQUIRES_WORKFLOW,
+            triggerFactory: triggerFactoryMock
+        });
+        const { pipelineWorkflow: legacyRequires } = await getWorkflow({
             pipelineConfig: LEGACY_AND_REQUIRES_WORKFLOW,
             triggerFactory: triggerFactoryMock
         });
-        const external = await getWorkflow({ pipelineConfig: EXTERNAL_TRIGGER, triggerFactory: triggerFactoryMock });
+        const { pipelineWorkflow: external } = await getWorkflow({
+            pipelineConfig: EXTERNAL_TRIGGER,
+            triggerFactory: triggerFactoryMock
+        });
 
         assert.deepEqual(requires, EXPECTED_OUTPUT);
         assert.deepEqual(legacyRequires, EXPECTED_OUTPUT);
@@ -53,7 +59,7 @@ describe('getWorkflow', () => {
                 bar: {}
             }
         };
-        const result = await getWorkflow({
+        const { pipelineWorkflow: result } = await getWorkflow({
             pipelineConfig,
             triggerFactory: triggerFactoryMock
         });
@@ -71,7 +77,7 @@ describe('getWorkflow', () => {
                 bar: { requires: ['foo'] }
             }
         };
-        const result = await getWorkflow({
+        const { pipelineWorkflow: result } = await getWorkflow({
             pipelineConfig,
             triggerFactory: triggerFactoryMock
         });
@@ -89,7 +95,7 @@ describe('getWorkflow', () => {
                 A: { requires: ['foo'] },
                 B: { requires: ['foo', 'stage@other:teardown'] },
                 C: { requires: ['stage@deploy:setup'], stage: { name: 'deploy', startFrom: true } },
-                D: { requires: ['~C'], stage: { name: 'deploy' } },
+                D: { requires: ['C'], stage: { name: 'deploy' } },
                 E: { requires: ['stage@test:setup'], stage: { name: 'test', startFrom: true } },
                 main: { requires: ['stage@other:setup'], stage: { name: 'other', startFrom: true } },
                 publish: { requires: ['main'], stage: { name: 'other' } }
@@ -117,7 +123,7 @@ describe('getWorkflow', () => {
             pipelineOnly: false
         });
 
-        assert.deepEqual(result.workflow, {
+        assert.deepEqual(result.pipelineWorkflow, {
             nodes: [
                 { name: '~pr' },
                 { name: '~commit' },
@@ -131,8 +137,8 @@ describe('getWorkflow', () => {
             edges: [
                 { src: '~commit', dest: 'foo' },
                 { src: 'foo', dest: 'A' },
-                { src: 'stage@other', dest: 'B' },
-                { src: 'foo', dest: 'B' },
+                { src: 'foo', dest: 'B', join: true },
+                { src: 'stage@other', dest: 'B', join: true },
                 { src: 'A', dest: 'stage@deploy' },
                 { src: 'foo', dest: 'stage@test' }
             ]
@@ -178,7 +184,7 @@ describe('getWorkflow', () => {
                 C: { requires: ['~A', '~B', '~sd@1234:foo'] }
             }
         };
-        const result = await getWorkflow({
+        const { pipelineWorkflow: result } = await getWorkflow({
             pipelineConfig,
             triggerFactory: triggerFactoryMock
         });
@@ -215,7 +221,7 @@ describe('getWorkflow', () => {
                 E: {}
             }
         };
-        const result = await getWorkflow({
+        const { pipelineWorkflow: result } = await getWorkflow({
             pipelineConfig,
             triggerFactory: triggerFactoryMock
         });
@@ -250,7 +256,7 @@ describe('getWorkflow', () => {
                 A: {}
             }
         };
-        const result = await getWorkflow({
+        const { pipelineWorkflow: result } = await getWorkflow({
             pipelineConfig,
             triggerFactory: triggerFactoryMock
         });
@@ -270,7 +276,7 @@ describe('getWorkflow', () => {
                 bax: { requires: ['bar', 'baz'] }
             }
         };
-        const result = await getWorkflow({
+        const { pipelineWorkflow: result } = await getWorkflow({
             pipelineConfig,
             triggerFactory: triggerFactoryMock
         });
@@ -302,7 +308,7 @@ describe('getWorkflow', () => {
                 bar: { requires: ['sd@111:baz', 'sd@1234:foo'] }
             }
         };
-        const result = await getWorkflow({
+        const { pipelineWorkflow: result } = await getWorkflow({
             pipelineConfig,
             triggerFactory: triggerFactoryMock,
             pipelineId: 123
@@ -344,7 +350,7 @@ describe('getWorkflow', () => {
                 }
             }
         };
-        const result = await getWorkflow({
+        const { pipelineWorkflow: result } = await getWorkflow({
             pipelineConfig,
             triggerFactory: triggerFactoryMock,
             pipelineId: 123


### PR DESCRIPTION
## Context

Stages might want to always run initialization or cleanups needed before jobs in a stage can be executed.

## Objective

This PR get workflowGraph for stages.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2767

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
