### PR TITLE
feat(3014): Process and include stage info in the workflow graph nodes when triggerFactory is not available

### DIFF
--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -47,40 +47,44 @@ const calculateNodes = async (jobs, triggerFactory, externalDownstreamOrs, exter
     if (!triggerFactory) {
         Object.keys(jobs).forEach(name => {
             nodes.add(name);
+            const stageObj = jobs[name].stage;
+
+            if (stageObj) {
+                jobNameToStageNameMap[name] = stageObj.name;
+            }
+
             if (Array.isArray(jobs[name].requires)) {
                 jobs[name].requires.forEach(n => nodes.add(filterNodeName(n)));
             }
         });
+    } else {
+        // new implementation. allow external join
+        await Promise.all(
+            Object.keys(jobs).map(async jobName => {
+                nodes.add(jobName);
+                const stageObj = jobs[jobName].stage;
 
-        return [...nodes].map(name => ({ name }));
+                if (stageObj) {
+                    jobNameToStageNameMap[jobName] = stageObj.name;
+                }
+
+                // upstream nodes
+                if (Array.isArray(jobs[jobName].requires)) {
+                    jobs[jobName].requires.forEach(n => nodes.add(filterNodeName(n)));
+                }
+
+                // downstream nodes
+                const externalDownstreamOr = jobName in externalDownstreamOrs ? externalDownstreamOrs[jobName] : [];
+                const externalDownstreamAnd = jobName in externalDownstreamAnds ? externalDownstreamAnds[jobName] : [];
+
+                externalDownstreamOr.forEach(dest => {
+                    nodes.add(dest.replace('~sd@', 'sd@'));
+                });
+
+                await buildExternalNodes(externalDownstreamAnd, nodes, triggerFactory);
+            })
+        );
     }
-
-    // new implementation. allow external join
-    await Promise.all(
-        Object.keys(jobs).map(async jobName => {
-            nodes.add(jobName);
-            const stageObj = jobs[jobName].stage;
-
-            if (stageObj) {
-                jobNameToStageNameMap[jobName] = stageObj.name;
-            }
-
-            // upstream nodes
-            if (Array.isArray(jobs[jobName].requires)) {
-                jobs[jobName].requires.forEach(n => nodes.add(filterNodeName(n)));
-            }
-
-            // downstream nodes
-            const externalDownstreamOr = jobName in externalDownstreamOrs ? externalDownstreamOrs[jobName] : [];
-            const externalDownstreamAnd = jobName in externalDownstreamAnds ? externalDownstreamAnds[jobName] : [];
-
-            externalDownstreamOr.forEach(dest => {
-                nodes.add(dest.replace('~sd@', 'sd@'));
-            });
-
-            await buildExternalNodes(externalDownstreamAnd, nodes, triggerFactory);
-        })
-    );
 
     return [...nodes].map(name => {
         const m = { name };


### PR DESCRIPTION
## Context

`stageName` is not being set for workflow graph `node` that is associated with a `stage` when `triggerFactory` is not available.

## Objective

`stageName` for workflow graph `node` that is associated with a `stage` should always be set irrespective of the availability of `triggerFactory`.


## References

https://github.com/screwdriver-cd/screwdriver/issues/3041

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
