### PR TITLE
feat(3022): Mark workflow node as virtual if it corresponds to a virtual job

### DIFF
--- a/lib/getWorkflow.js
+++ b/lib/getWorkflow.js
@@ -86,16 +86,24 @@ const calculateNodes = async (jobs, triggerFactory, externalDownstreamOrs, exter
         );
     }
 
+    const annotations = [
+        { annotation: 'annotations>screwdriver.cd/displayName', fieldName: 'displayName', default: undefined },
+        { annotation: 'annotations>screwdriver.cd/virtualJob', fieldName: 'virtual', default: undefined }
+    ];
+
     return [...nodes].map(name => {
         const m = { name };
-        const displayName = hoek.reach(jobs[name], 'annotations>screwdriver.cd/displayName', {
-            separator: '>',
-            default: undefined
-        });
 
-        if (displayName !== undefined) {
-            m.displayName = displayName;
-        }
+        annotations.forEach(({ annotation, fieldName, defaultValue }) => {
+            const fieldValue = hoek.reach(jobs[name], annotation, {
+                separator: '>',
+                default: defaultValue
+            });
+
+            if (fieldValue !== undefined) {
+                m[fieldName] = fieldValue;
+            }
+        });
 
         const stageName = jobNameToStageNameMap[name];
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@hapi/hoek": "^10.0.1",
-    "screwdriver-data-schema": "^23.0.4"
+    "screwdriver-data-schema": "^23.1.0"
   },
   "release": {
     "branches": [

--- a/test/lib/getWorkflow.test.js
+++ b/test/lib/getWorkflow.test.js
@@ -256,11 +256,19 @@ describe('getWorkflow', () => {
     describe('should handle stages', async () => {
         const PIPELINE_CONFIG = {
             jobs: {
-                'stage@alpha:setup': { requires: ['~commit'], stage: { name: 'alpha' } },
+                'stage@alpha:setup': {
+                    requires: ['~commit'],
+                    stage: { name: 'alpha' },
+                    annotations: { 'screwdriver.cd/virtualJob': true }
+                },
                 'alpha-deploy': { requires: ['stage@alpha:setup'], stage: { name: 'alpha' } },
                 'alpha-test': { requires: ['alpha-deploy'], stage: { name: 'alpha' } },
                 'alpha-certify': { requires: ['alpha-test'], stage: { name: 'alpha' } },
-                'stage@alpha:teardown': { requires: ['alpha-certify'], stage: { name: 'alpha' } },
+                'stage@alpha:teardown': {
+                    requires: ['alpha-certify'],
+                    stage: { name: 'alpha' },
+                    annotations: { 'screwdriver.cd/virtualJob': true }
+                },
                 'stage@beta:setup': { requires: ['~stage@alpha:teardown'], stage: { name: 'beta' } },
                 'beta-deploy': { requires: ['~stage@beta:setup'], stage: { name: 'beta' } },
                 'beta-test': { requires: ['~beta-deploy'], stage: { name: 'beta' } },
@@ -299,11 +307,11 @@ describe('getWorkflow', () => {
             nodes: [
                 { name: '~pr' },
                 { name: '~commit' },
-                { name: 'stage@alpha:setup', stageName: 'alpha' },
+                { name: 'stage@alpha:setup', stageName: 'alpha', virtual: true },
                 { name: 'alpha-deploy', stageName: 'alpha' },
                 { name: 'alpha-test', stageName: 'alpha' },
                 { name: 'alpha-certify', stageName: 'alpha' },
-                { name: 'stage@alpha:teardown', stageName: 'alpha' },
+                { name: 'stage@alpha:teardown', stageName: 'alpha', virtual: true },
                 { name: 'stage@beta:setup', stageName: 'beta' },
                 { name: 'beta-deploy', stageName: 'beta' },
                 { name: 'beta-test', stageName: 'beta' },


### PR DESCRIPTION
## Context

Workflow graph node (Ex: implicit setup/teardown job of a stage) for an event is identified as virtual based on the presence/value of `screwdriver.cd/virtualJob` annotation in the corresponding job definition.

Since the job definition reflects the latest configuration from `screwdriver.yaml`, referring to current annotations of the job may not be reliable to identify it as virtual for an event.
We need a way to preserve whether the job is virtual or not when event is created.

## Objective

Add a new attribute `virtual` in the workflow graph `node` to indicate whether it is virtual or not.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3022

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
