### PR TITLE
fix(3413): skip jobs between stage setup and startFrom stage job only if they belong to the same stage

### DIFF
--- a/lib/getNextJobs.js
+++ b/lib/getNextJobs.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const { PR_JOB_NAME, EXTERNAL_TRIGGER_ALL } = require('screwdriver-data-schema').config.regex;
-const STAGE_SETUP_PATTERN = /^stage@([\w-]+)(?::setup)$/;
+const { PR_JOB_NAME, EXTERNAL_TRIGGER_ALL, STAGE_SETUP_PATTERN } = require('screwdriver-data-schema').config.regex;
 
 /**
  * Check if the job is setup job with setup suffix
@@ -13,15 +12,15 @@ function isStageSetup(jobName) {
 }
 
 /**
- * Check if the job is a stage job
+ * get the stage name of a job
  * @param  {String} jobName                 Job name
  * @param  {Object} workflowGraph           Workflow Graph
- * @return {Boolean}
+ * @return {String}                         Stage name
  */
-function isStageJob(workflowGraph, jobName) {
+function getStageName(workflowGraph, jobName) {
     const jobNode = workflowGraph.nodes.find(n => n.name === jobName);
 
-    return jobNode.stageName !== undefined;
+    return jobNode ? jobNode.stageName : null;
 }
 
 /**
@@ -45,16 +44,16 @@ const getNextJobs = (workflowGraph, config) => {
         throw new Error('Must provide a PR number with "~pr" trigger');
     }
 
-    // Check if the current job is a stage setup and the startFrom job is a non setup stage job
-    if (
-        isStageSetup(config.trigger) &&
-        config.startFrom !== undefined &&
-        !isStageSetup(config.startFrom) &&
-        isStageJob(workflowGraph, config.startFrom)
-    ) {
-        jobs.add(config.startFrom);
+    // Check if the current job is a stage setup, the startFrom job is a non setup job in the same stage
+    if (isStageSetup(config.trigger)) {
+        const startFromStageName = getStageName(workflowGraph, config.startFrom);
+        const triggerStageName = getStageName(workflowGraph, config.trigger);
 
-        return Array.from(jobs);
+        if (!isStageSetup(config.startFrom) && startFromStageName === triggerStageName) {
+            jobs.add(config.startFrom);
+
+            return Array.from(jobs);
+        }
     }
 
     // Check if the job is triggerd by chainPR with regexp

--- a/test/data/expected-output.json
+++ b/test/data/expected-output.json
@@ -14,7 +14,13 @@
         { "name": "ci-deploy", "stageName":  "integration"},
         { "name": "ci-test", "stageName":  "integration"},
         { "name": "ci-certify", "stageName":  "integration"},
-        { "name": "stage@integration:teardown", "stageName":  "integration"}
+        { "name": "stage@integration:teardown", "stageName":  "integration"},
+
+        { "name": "stage@alpha:setup", "stageName":  "alpha"},
+        { "name": "a-deploy", "stageName":  "alpha"},
+        { "name": "a-test", "stageName":  "alpha"},
+        { "name": "a-certify", "stageName":  "alpha"},
+        { "name": "stage@alpha:teardown", "stageName":  "alpha"}
 
     ],
     "edges": [
@@ -30,6 +36,12 @@
         { "src": "stage@integration:setup", "dest": "ci-deploy" },
         { "src": "ci-deploy", "dest": "ci-test" },
         { "src": "ci-test", "dest": "ci-certify" },
-        { "src": "ci-certify", "dest": "stage@integration:teardown" }
+        { "src": "ci-certify", "dest": "stage@integration:teardown" },
+
+        { "src": "stage@integration:teardown", "dest": "stage@alpha:setup" },
+        { "src": "stage@alpha:setup", "dest": "a-deploy" },
+        { "src": "a-deploy", "dest": "a-test" },
+        { "src": "a-test", "dest": "a-certify" },
+        { "src": "a-certify", "dest": "stage@alpha:teardown" }
     ]
 }

--- a/test/data/requires-workflow.json
+++ b/test/data/requires-workflow.json
@@ -10,6 +10,12 @@
         "ci-deploy": { "requires": ["~stage@integration:setup"], "stage": { "name": "integration" } },
         "ci-test": { "requires": ["~ci-deploy"], "stage": { "name": "integration" } },
         "ci-certify": { "requires": ["~ci-test"], "stage": { "name": "integration" } },
-        "stage@integration:teardown": { "requires": ["~ci-certify"], "stage": { "name": "integration" } }
+        "stage@integration:teardown": { "requires": ["~ci-certify"], "stage": { "name": "integration" } },
+
+        "stage@alpha:setup": { "requires": ["~stage@integration:teardown"], "stage": { "name": "alpha" } },
+        "a-deploy": { "requires": ["~stage@alpha:setup"], "stage": { "name": "alpha" } },
+        "a-test": { "requires": ["~a-deploy"], "stage": { "name": "alpha" } },
+        "a-certify": { "requires": ["~a-test"], "stage": { "name": "alpha" } },
+        "stage@alpha:teardown": { "requires": ["~a-certify"], "stage": { "name": "alpha" } }
     }
 }

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -20,14 +20,22 @@ describe('getNextJobs', () => {
         );
     });
 
-    it('should figure out what jobs start next', () => {
-        // trigger for a stage setup with the startFrom as a stage setup
+    it.only('should figure out what jobs start next', () => {
+        // trigger for a stage setup with the startFrom as a stage setup job
         assert.deepEqual(
             getNextJobs(WORKFLOW, {
                 trigger: 'stage@integration:setup',
                 startFrom: 'ci-test'
             }),
             ['ci-test']
+        );
+        // trigger for a stage setup with the startFrom as a stage
+        assert.deepEqual(
+            getNextJobs(WORKFLOW, {
+                trigger: 'stage@integration:setup',
+                startFrom: 'stage@integration'
+            }),
+            ['ci-deploy']
         );
         // trigger for a pr event
         assert.deepEqual(

--- a/test/lib/getNextJobs.test.js
+++ b/test/lib/getNextJobs.test.js
@@ -20,7 +20,7 @@ describe('getNextJobs', () => {
         );
     });
 
-    it.only('should figure out what jobs start next', () => {
+    it('should figure out what jobs start next', () => {
         // trigger for a stage setup with the startFrom as a stage setup job
         assert.deepEqual(
             getNextJobs(WORKFLOW, {
@@ -34,6 +34,30 @@ describe('getNextJobs', () => {
             getNextJobs(WORKFLOW, {
                 trigger: 'stage@integration:setup',
                 startFrom: 'stage@integration'
+            }),
+            ['ci-deploy']
+        );
+        // trigger for a stage setup with the startFrom as the stage setup of same stage
+        assert.deepEqual(
+            getNextJobs(WORKFLOW, {
+                trigger: 'stage@integration:setup',
+                startFrom: 'stage@integration:setup'
+            }),
+            ['ci-deploy']
+        );
+        // trigger for a stage setup with the startFrom as the stage job in a different stage
+        assert.deepEqual(
+            getNextJobs(WORKFLOW, {
+                trigger: 'stage@integration:setup',
+                startFrom: 'a-test'
+            }),
+            ['ci-deploy']
+        );
+        // trigger for a stage setup with the startFrom as the stage setup of a different stage
+        assert.deepEqual(
+            getNextJobs(WORKFLOW, {
+                trigger: 'stage@integration:setup',
+                startFrom: 'stage@alpha:setup'
             }),
             ['ci-deploy']
         );


### PR DESCRIPTION

## Context

Currently, getNextJobs returns the next job in workflow graph after the stage setup, regardless of the startFrom being in the middle of that stage or not

## Objective

Return the startFrom job as the next job to execute if the current job is a stage setup and startFrom job is a non setup job in that stage

## References

https://github.com/screwdriver-cd/screwdriver/issues/3143

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
