### PR TITLE
feat(3171): Pull in latest data-schema to persist pipeline template workflowGraph in a new column

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@hapi/hoek": "^10.0.1",
-    "screwdriver-data-schema": "^23.1.0"
+    "screwdriver-data-schema": "^24.0.0"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config

## Context

Changes were made in https://github.com/screwdriver-cd/data-schema/pull/571 (and related PRs) to store `workflowGraph` of pipeline template as part of the `config` 

## Objective

Move `workflowGraph` out of `config` and keep it at the same level as `config`

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
