### PR TITLE
fix(3176): Use data-schema regex to filter for PR jobs

### DIFF
--- a/lib/getSrcForJoin.js
+++ b/lib/getSrcForJoin.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { PR_JOB_NAME } = require('screwdriver-data-schema').config.regex;
+
 /**
  * Find the non PR job from given workflowGragh and dest job
  * @method findJob
@@ -47,14 +49,14 @@ function findPRJobs(workflowGraph, destJobName) {
 }
 
 /**
- * Return PR job or not
- * PR job name certainly has ":". e.g. "PR-1:jobName"
+ * Return if PR job or not
+ * PR job name should match regex used in data-schema. e.g. "PR-1:jobName"
  * @method isPR
  * @param  {String}  destJobName       The dest job name which has 'PR-{num}:' prefix
  * @return {Boolean}
  */
 function isPR(destJobName) {
-    return destJobName.includes(':');
+    return PR_JOB_NAME.test(destJobName);
 }
 
 /**

--- a/lib/getSrcForJoin.js
+++ b/lib/getSrcForJoin.js
@@ -23,7 +23,7 @@ function findJobs(workflowGraph, destJobName) {
 
 /**
  * Find the PR job from given workflowGragh and dest job
- * Given dest job includes `PR-{PR number}:` prefix, so it need to remove prefix at first
+ * Since the dest job has a `PR-{PR number}:` prefix, remove prefix first
  * @method findPRJobs
  * @param  {Object} workflowGraph       Directed graph representation of workflow
  * @param  {String} destJobName         The dest job name to be triggered after a join
@@ -31,7 +31,7 @@ function findJobs(workflowGraph, destJobName) {
  */
 function findPRJobs(workflowGraph, destJobName) {
     const jobs = new Set();
-    const [prPrefix, prJobName] = destJobName.split(':');
+    const [, prPrefix, prJobName] = destJobName.match(PR_JOB_NAME);
 
     workflowGraph.edges.forEach(edge => {
         if (edge.dest === prJobName && edge.join) {

--- a/test/lib/getSrcForJoin.test.js
+++ b/test/lib/getSrcForJoin.test.js
@@ -58,10 +58,13 @@ describe('isPR', () => {
 
     it('sholud return true if job name has PR prefix', () => {
         assert.isTrue(isPR('PR-1:testJobName'));
+        assert.isTrue(isPR('PR-1'));
     });
 
     it('sholud return false if job name does not have PR prefix', () => {
         assert.isFalse(isPR('testJobName'));
+        assert.isFalse(isPR('sd@123:component'));
+        assert.isFalse(isPR('stage@sandbox:teardown'));
     });
 });
 


### PR DESCRIPTION
## Context

Currently, job name with `:`  is considered a PR job. So `stage@sandbox:teardown` is being treated as a PR job. To find the source nodes for join, edges are matched with only "teardown" in the dest, causing stage teardown to run prematurely.

## Objective

This PR uses data-schema regex to filter for PR jobs.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3176

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
